### PR TITLE
IP, MPLS, FRAMEWORK: Abbreviations fixed

### DIFF
--- a/data-plane-framework/draft-ietf-detnet-data-plane-framework.xml
+++ b/data-plane-framework/draft-ietf-detnet-data-plane-framework.xml
@@ -175,7 +175,6 @@
             <t hangText="PREOF">Packet Replication, Elimination and Ordering Functions.</t>
             <t hangText="POF">Packet Ordering Function.</t>
             <t hangText="PSN">Packet Switched Network.</t>
-            <t hangText="PW">PseudoWire.</t>
             <t hangText="QoS">Quality of Service.</t>
             <t hangText="TSN">Time-Sensitive Network.</t>
           </list>

--- a/ip/draft-ietf-detnet-ip.xml
+++ b/ip/draft-ietf-detnet-ip.xml
@@ -167,12 +167,8 @@
             <t hangText="L3">Layer-3.</t>
             <t hangText="LSP">Label-switched path.</t>
             <t hangText="MPLS">Multiprotocol Label Switching.</t>
-            <t hangText="PE">Provider Edge.</t>
             <t hangText="PREOF">Packet Replication, Ordering and Elimination Function.</t>
-            <t hangText="PSN">Packet Switched Network.</t>
-            <t hangText="PW">Pseudowire.</t>
             <t hangText="QoS">Quality of Service.</t>
-            <t hangText="TE">Traffic Engineering.</t>
             <t hangText="TSN">Time-Sensitive Networking, TSN is a Task Group of the IEEE
             802.1 Working Group.</t>
           </list>

--- a/mpls/draft-ietf-detnet-mpls.xml
+++ b/mpls/draft-ietf-detnet-mpls.xml
@@ -206,22 +206,13 @@
   <t>
    The following abbreviations are used in this document:
    <list style="hanging" hangIndent="14">
-    <t hangText="AC">Attachment Circuit.</t>
-    <t hangText="CE">Customer Edge equipment.</t>
     <t hangText="CoS">Class of Service.</t>
     <t hangText="CW">Control Word.</t>
     <t hangText="DetNet">Deterministic Networking.</t>
-    <t hangText="DF">DetNet Flow.</t>
-    <t hangText="DN-IWF">DetNet Inter-Working Function.</t>
-    <t hangText="L2">Layer 2.</t>
-    <t hangText="L2VPN">Layer 2 Virtual Private Network.</t>
-    <t hangText="L3">Layer 3.</t>
     <t hangText="LSR">Label Switching Router.</t>
     <t hangText="MPLS">Multiprotocol Label Switching.</t>
     <t hangText="MPLS-TE">Multiprotocol Label Switching - Traffic Engineering.</t>
     <t hangText="MPLS-TP">Multiprotocol Label Switching - Transport Profile.</t>
-    <t hangText="MS-PW">Multi-Segment PseudoWire (MS-PW).</t>
-    <t hangText="NSP">Native Service Processing.</t>
     <t hangText="OAM">Operations, Administration, and Maintenance.</t>
     <t hangText="PE">Provider Edge.</t>
     <t hangText="PEF">Packet Elimination Function.</t>


### PR DESCRIPTION
Removing unused abbreviations.