### PR TITLE
Monitoring and Control info section addition/cleanup, other editorial changes

### DIFF
--- a/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
+++ b/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
@@ -132,10 +132,10 @@
       </t>
 -->
       <t>
-		This document specifies use of the IP DetNet encapsulation over an
-		MPLS network. It maps the IP data plane encapsulation described in <xref
-		target="I-D.ietf-detnet-ip"/> to the DetNet MPLS data plane defined in <xref
-		target="I-D.ietf-detnet-mpls"/>.
+                This document specifies use of the IP DetNet encapsulation over an
+                MPLS network. It maps the IP data plane encapsulation described in <xref
+                target="I-D.ietf-detnet-ip"/> to the DetNet MPLS data plane defined in <xref
+                target="I-D.ietf-detnet-mpls"/>.
       </t>
     </section>
 
@@ -144,17 +144,17 @@
         <t>
           This document uses the terminology and concepts established in
           the DetNet architecture <xref target="I-D.ietf-detnet-architecture"/>
-		  and <xref target="I-D.ietf-detnet-data-plane-framework"/>, and the 
-		  reader is assumed to be familiar with these documents and their
-		  terminology.
+                  and <xref target="I-D.ietf-detnet-data-plane-framework"/>, and the
+                  reader is assumed to be familiar with these documents and their
+                  terminology.
         </t>
       </section>
 
       <section title="Abbreviations">
         <t>
           This document uses the abbreviations defined in the DetNet
-		  architecture <xref target="I-D.ietf-detnet-architecture"/> and 
-		  <xref target="I-D.ietf-detnet-data-plane-framework"/>.
+                  architecture <xref target="I-D.ietf-detnet-architecture"/> and
+                  <xref target="I-D.ietf-detnet-data-plane-framework"/>.
           This document uses the following abbreviations:
           <list style="hanging" hangIndent="14">
             <t hangText="CE">Customer Edge equipment.</t>
@@ -236,7 +236,7 @@
 
      </section>
 
-	
+        
     <!-- ===================================================================== -->
 
     <section anchor="ip-over-mpls" title="IP over DetNet MPLS">
@@ -257,15 +257,15 @@
         <t>
           <xref target="fig_ip_detnet"/> illustrated DetNet
           enabled End Systems (hosts), connected to DetNet (DN) enabled
-          IP networks, operating over a DetNet aware MPLS network. 
-          iUsing this figure we can have a case where the Relay nodes act as 
+          IP networks, operating over a DetNet aware MPLS network.
+          iUsing this figure we can have a case where the Relay nodes act as
           T-PEs and sit at the boundary of the MPLS
           domain since the non-MPLS domain is DetNet aware.  This case
           is very similar to the DetNet MPLS Network figure 2 in <xref
                   target="I-D.ietf-detnet-mpls"/>.  However in  <xref
-                  target="I-D.ietf-detnet-mpls"/>  figure 2 the T-PEs are located at the 
-         end syetem and MPLS spans the whole DetNet service.  
-         
+                  target="I-D.ietf-detnet-mpls"/>  figure 2 the T-PEs are located at the
+         end syetem and MPLS spans the whole DetNet service.
+
           The primary difference in this document is that the Relay nodes are at the edges of the
           MPLS domain and therefore function as T-PEs, and that iMPLS service
           sub-layer functions are not provided over the DetNet IP
@@ -316,7 +316,7 @@ System  |   +--------+       +--------+       +--------+   |  System
         <t>
           <xref target="fig_ip_detnet"/> illustrates DetNet
           enabled End Systems (hosts), connected to DetNet (DN) enabled
-          MPLS network.  A similar situation occurs when 
+          MPLS network.  A similar situation occurs when
           end systems are are not DetNet aware.  In this case, edge nodes sit at
           the boundary of the MPLS domain since it is also a DetNet domain
           boundary.  The edge nodes provide DetNet service proxies for the
@@ -349,9 +349,9 @@ System  |   +--------+       +--------+       +--------+   |  System
       </t>
       <t>
         [Editor's note: several proposed changes on the figure.
-		Intention is to clarify relationship of the various flows.]
+                Intention is to clarify relationship of the various flows.]
       </t>
- 
+
   <figure title="Example DetNet IP over MPLS Sub-Network Formats"
               anchor="fig_dn_ip_mpls_sn_ex">
         <artwork align="center"><![CDATA[
@@ -363,9 +363,9 @@ App-Flow <-+       |NProto|  |NProto|  |NProto|            : :(1)
  for MPLS  |       +------+  +------+  +------+            : :
            |       |  IP  |  |  IP  |  |  IP  |            : v
            \-> +---+======+--+======+--+======+-----+      :
-DetNet-MPLS        | d-CW |  | d-CW |  | d-CW |            : 
+DetNet-MPLS        | d-CW |  | d-CW |  | d-CW |            :
                    +------+  +------+  +------+            :(2)
-                   |Labels|  |Labels|  |Labels|            v 
+                   |Labels|  |Labels|  |Labels|            v
                +---+======+--+======+--+======+-----+
 Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
                    +------+  +------+  +------+
@@ -382,25 +382,25 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
         In the figure, "App-Flow" indicates the payload carried by
         the DetNet IP data plane.  "IP" and "NProto" indicate the fields
         described in Section 7.1.1. IP Header Information and Section 7.1.2.
-		Other Protocol Header Information in <xref target="I-D.ietf-detnet-ip"/>, 
-		respectively.  
-	
-		"MPLS App-Flow" indicates
+                Other Protocol Header Information in <xref target="I-D.ietf-detnet-ip"/>,
+                respectively.
+        
+                "MPLS App-Flow" indicates
         that an individual DetNet IP flow is the payload from the
         perspective of the DetNet MPLS data plane defined in <xref
         target="I-D.ietf-detnet-mpls"/>.
       </t>
       <t>
-	Per <xref target="I-D.ietf-detnet-mpls"/>, the DetNet MPLS data plane
-	uses a single S-Label to support a single app flow. Section 7.1. DetNet
-	IP Flow Identification Procedures in <xref
-		target="I-D.ietf-detnet-ip"/> states that a single DetNet flow
-	is identified based on IP, and next level protocol, header information.
-	Section 7.4. Aggregation Considerations in <xref
-		target="I-D.ietf-detnet-ip"/> defines that aggregation is
-	supported through the use of prefixes, wildcards, bitmasks, and port
-	ranges.  Collectively, this results in the fairly straight forward
-	procedures defined in this section.
+        Per <xref target="I-D.ietf-detnet-mpls"/>, the DetNet MPLS data plane
+        uses a single S-Label to support a single app flow. Section 7.1. DetNet
+        IP Flow Identification Procedures in <xref
+                target="I-D.ietf-detnet-ip"/> states that a single DetNet flow
+        is identified based on IP, and next level protocol, header information.
+        Section 7.4. Aggregation Considerations in <xref
+                target="I-D.ietf-detnet-ip"/> defines that aggregation is
+        supported through the use of prefixes, wildcards, bitmasks, and port
+        ranges.  Collectively, this results in the fairly straight forward
+        procedures defined in this section.
       </t>
       <t>
         As shown in <xref target="fig_ip_pw_detnet"/>, DetNet relay nodes
@@ -411,9 +411,9 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
         flow identifiers; and ensuring proper traffic treatment.
       </t>
       <t>
-      Mapping of IP to the MPLS Detnet is similar for IP Detnet flows and IP flows. 
-      The six-tuple of IP is mapped to the S-Label in both cases.  
-      The various fields may be mapped or ignored when going from IP to MPLS. 
+      Mapping of IP to the MPLS Detnet is similar for IP Detnet flows and IP flows.
+      The six-tuple of IP is mapped to the S-Label in both cases.
+      The various fields may be mapped or ignored when going from IP to MPLS.
       </t>
       </section>
      </section>
@@ -423,57 +423,57 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
                title="DetNet IP over DetNet MPLS Flow Identification
                       Procedures">
       <t>
-        [Editor's note: several proposed changes to clarify referred 
-		components. Confusing usage of app-flow terminology.]
+        [Editor's note: several proposed changes to clarify referred
+                components. Confusing usage of app-flow terminology.]
       </t>
 
         <t>
-	  A DetNet relay node (ingress T-PE) that sends a DetNet IP flow over a DetNet MPLS network
-	  MUST map that single DetNet IP flow into a single MPLS DetNet flow and MUST
-	  process it in accordance to the procedures defined in
-	  <xref target="I-D.ietf-detnet-mpls"/> Section 6.1.  PRF MAY be
-	  supported for DetNet IP flows sent over an DetNet MPLS network.
-	  Aggregation MAY be supported as defined in <xref
-		  target="I-D.ietf-detnet-mpls"/> Section 5.4. Aggregation
-	  considerations in <xref target="I-D.ietf-detnet-ip"/> MAY be used to
-	  identify an individual DetNet IP flow. The provisioning of the
-	  mapping of DetNet IP flows to DetNet MPLS flows MUST
-	  be supported via configuration, e.g., via the controller plane.
+          A DetNet relay node (ingress T-PE) that sends a DetNet IP flow over a DetNet MPLS network
+          MUST map that single DetNet IP flow into a single MPLS DetNet flow and MUST
+          process it in accordance to the procedures defined in
+          <xref target="I-D.ietf-detnet-mpls"/> Section 6.1.  PRF MAY be
+          supported for DetNet IP flows sent over an DetNet MPLS network.
+          Aggregation MAY be supported as defined in <xref
+                  target="I-D.ietf-detnet-mpls"/> Section 5.4. Aggregation
+          considerations in <xref target="I-D.ietf-detnet-ip"/> MAY be used to
+          identify an individual DetNet IP flow. The provisioning of the
+          mapping of DetNet IP flows to DetNet MPLS flows MUST
+          be supported via configuration, e.g., via the controller plane.
         </t>
         <t>
-	  A DetNet relay node (egress T-PE) MAY be provisioned to handle packets received via the
-	  DetNet MPLS data plane as DetNet IP flows.  A single incoming DetNet MPLS
-	  flow MAY be treated as a single DetNet IP flow, without
-	  examination of IP headers. Alternatively, packets received via the
-	  DetNet MPLS data plane MAY follow the normal DetNet IP flow
-	  identification procedures defined in <xref
-		  target="I-D.ietf-detnet-ip"/>  Section 7.1.
+          A DetNet relay node (egress T-PE) MAY be provisioned to handle packets received via the
+          DetNet MPLS data plane as DetNet IP flows.  A single incoming DetNet MPLS
+          flow MAY be treated as a single DetNet IP flow, without
+          examination of IP headers. Alternatively, packets received via the
+          DetNet MPLS data plane MAY follow the normal DetNet IP flow
+          identification procedures defined in <xref
+                  target="I-D.ietf-detnet-ip"/>  Section 7.1.
 
-	  An implementation MUST support the provisioning for handling any
-	  received DetNet MPLS data plane as DetNet IP flows via configuration.
-	  Note that such configuration MAY include support from PEOF on the
-	  incoming DetNet MPLS flow.
+          An implementation MUST support the provisioning for handling any
+          received DetNet MPLS data plane as DetNet IP flows via configuration.
+          Note that such configuration MAY include support from PEOF on the
+          incoming DetNet MPLS flow.
         </t>
       </section>
       <section anchor="iom-svc"
                title="DetNet IP over DetNet MPLS Traffic Treatment Procedures">
         <t>
-	  The traffic treatment required for a particular DetNet IP flow is
-	  provisioned via configuration or the controller plane. When an DetNet
-	  IP flow is sent over DetNet MPLS, a DetNet relay node MUST ensure that the
-	  provisioned DetNet IP traffic treatment is provided at the forwarding
-	  sub-layer as described in <xref target="I-D.ietf-detnet-mpls"/>
-	  Section 5.2. Note that the PRF function MAY be utilized when sending
-	  IP over MPLS.
+          The traffic treatment required for a particular DetNet IP flow is
+          provisioned via configuration or the controller plane. When an DetNet
+          IP flow is sent over DetNet MPLS, a DetNet relay node MUST ensure that the
+          provisioned DetNet IP traffic treatment is provided at the forwarding
+          sub-layer as described in <xref target="I-D.ietf-detnet-mpls"/>
+          Section 5.2. Note that the PRF function MAY be utilized when sending
+          IP over MPLS.
         </t>
         <t>
           Traffic treatment for DetNet IP flows received over the DetNet
           MPLS data plane MUST follow Section 7.3 DetNet IP Traffic
-		  Treatment Procedures in <xref target="I-D.ietf-detnet-ip"/>.
+                  Treatment Procedures in <xref target="I-D.ietf-detnet-ip"/>.
         </t>
       </section>
     </section>
-	
+        
     <section title="Security Considerations">
      <t>
        This draft does not have additional security considerations.  Security
@@ -482,7 +482,7 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
        considerations are described in <xref
                target="I-D.ietf-detnet-architecture"/>.  MPLS and IP specific
        considerations are described in <xref target="I-D.ietf-detnet-mpls"/>
-       and <xref target="I-D.ietf-detnet-ip"/>.       
+       and <xref target="I-D.ietf-detnet-ip"/>.
       </t>
       <t>
        Security aspects which are unique to DetNet are those whose aim is to
@@ -526,21 +526,21 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
         authentication and authorization of devices within the DetNet domain.
         </t>
 
-	</section>
+        </section>
 
 
     <section anchor="iana" title="IANA Considerations">
       <t>
-	  This document makes no IANA requests.
+          This document makes no IANA requests.
       </t>
     </section>
 
     <section anchor="acks" title="Acknowledgements">
       <t>
-		The authors wish to thank Pat Thaler, Norman Finn, Loa Anderson, David Black, 
-		Rodney Cummings, Ethan Grossman, Tal Mizrahi, David Mozes, Craig Gunther, 
-		George Swallow, Yuanlong Jiang and Carlos J. Bernardos for their
-		various contributions to this work.
+                The authors wish to thank Pat Thaler, Norman Finn, Loa Anderson, David Black,
+                Rodney Cummings, Ethan Grossman, Tal Mizrahi, David Mozes, Craig Gunther,
+                George Swallow, Yuanlong Jiang and Carlos J. Bernardos for their
+                various contributions to this work.
       </t>
     </section>
 
@@ -553,9 +553,9 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
       <?rfc include="reference.RFC.2119"?>
       <?rfc include="reference.RFC.8174"?>
       <?rfc include="reference.I-D.ietf-detnet-architecture"?>
-	  <?rfc include="reference.I-D.ietf-detnet-mpls'?>
+          <?rfc include="reference.I-D.ietf-detnet-mpls'?>
       <?rfc include="reference.I-D.ietf-detnet-ip'?>
-	</references>
+        </references>
 
     <references title="Informative references">
       <?rfc include="reference.I-D.ietf-detnet-security"?>
@@ -576,3 +576,4 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
 
   </back>
 </rfc>
+

--- a/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
+++ b/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
@@ -347,11 +347,12 @@ System  |   +--------+       +--------+       +--------+   |  System
         Sub-Network format is shown in <xref
         target="fig_dn_ip_mpls_sn_ex"/>.
       </t>
+      <!-- 
       <t>
         [Editor's note: several proposed changes on the figure.
                 Intention is to clarify relationship of the various flows.]
       </t>
-
+      -->
   <figure title="Example DetNet IP over MPLS Sub-Network Formats"
               anchor="fig_dn_ip_mpls_sn_ex">
         <artwork align="center"><![CDATA[
@@ -422,17 +423,18 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
       <section anchor="iom-ids"
                title="DetNet IP over DetNet MPLS Flow Identification
                       Procedures">
+ <!-- 
       <t>
         [Editor's note: several proposed changes to clarify referred
                 components. Confusing usage of app-flow terminology.]
       </t>
-
+  -->
         <t>
           A DetNet relay node (ingress T-PE) that sends a DetNet IP flow over a DetNet MPLS network
-          MUST map that single DetNet IP flow into a single MPLS DetNet flow and MUST
+          MUST map a DetNet IP flow, as identified in <xref target="I-D.ietf-detnet-ip"/> into a single MPLS DetNet flow and MUST
           process it in accordance to the procedures defined in
           <xref target="I-D.ietf-detnet-mpls"/> Section 6.1.  PRF MAY be
-          supported for DetNet IP flows sent over an DetNet MPLS network.
+          supported at the MPLS level for DetNet IP flows sent over an DetNet MPLS network.
           Aggregation MAY be supported as defined in <xref
                   target="I-D.ietf-detnet-mpls"/> Section 5.4. Aggregation
           considerations in <xref target="I-D.ietf-detnet-ip"/> MAY be used to
@@ -448,7 +450,8 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
           DetNet MPLS data plane MAY follow the normal DetNet IP flow
           identification procedures defined in <xref
                   target="I-D.ietf-detnet-ip"/>  Section 7.1.
-
+        </t>
+        <t>
           An implementation MUST support the provisioning for handling any
           received DetNet MPLS data plane as DetNet IP flows via configuration.
           Note that such configuration MAY include support from PEOF on the
@@ -474,6 +477,57 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
       </section>
     </section>
         
+    <!-- ===================================================================== -->
+
+    <section anchor="mc_summary"
+             title="Management and Control Information Summary">
+      <t>
+        The following summarizes the set of information that is needed to
+        support DetNet IP over DetNet MPLS at the MPLS ingress node:
+        <list style="symbols">
+          <t>
+            Each MPLS App-Flow is identified using the IP flow
+            identification information as defined in <xref
+            target="I-D.ietf-detnet-ip"/>. The information is summarized
+            in Section 6 of that document, and includes all wildcards,
+            port ranges and ability to ignore specific IP fields.
+          </t>
+          <t>
+            The DetNet MPLS service that is to be used to send the
+            matching IP traffic.  Logically this is a pointer to the
+            information provided in <xref
+            target="I-D.ietf-detnet-mpls"/> Section 5.1, and includes
+            both service and traffic delivery information.
+          </t>
+        </list>
+      </t>
+      <t>
+        The following summarizes the set of information that is needed to
+        support DetNet IP over DetNet MPLS at the MPLS egress node:
+        <list style="symbols">
+          <t>
+            S-Label values that are carrying MPLS over IP encapsulated
+            traffic.
+          </t>
+          <t>
+            For each S-Label, how the received traffic is to be
+            handled. The traffic may be processed according as any other
+            DetNet IP traffic as defined in this document or in <xref
+            target="I-D.ietf-detnet-ip"/>, or the traffic may be
+            directly treated as an MPLS App-flow for additional
+            processing according to  <xref
+            target="I-D.ietf-detnet-mpls"/>.
+          </t>
+        </list>
+      </t>
+      <t>
+        It is the responsibility of the DetNet controller plane to
+        properly provision both flow identification information and
+        the flow specific resources needed to provided the traffic
+        treatment needed to meet each flow's service requirements.
+        This applies for aggregated and individual flows.
+      </t>
+    </section>
     <section title="Security Considerations">
      <t>
        This draft does not have additional security considerations.  Security

--- a/mpls-over-udp-ip/draft-ietf-detnet-mpls-over-udp-ip.xml
+++ b/mpls-over-udp-ip/draft-ietf-detnet-mpls-over-udp-ip.xml
@@ -73,17 +73,17 @@
     DetNet Data Plane: MPLS over UDP/IP</title>
 
   <author role="editor" fullname="Bal&aacute;zs Varga" initials="B." surname="Varga">
-	<organization>Ericsson</organization>
-	<address>
-	 <postal>
-	  <street>Magyar Tudosok krt. 11.</street>
-	  <city>Budapest</city>
-	  <country>Hungary</country>
-	  <code>1117</code>
-	 </postal>
-	 <email>balazs.a.varga@ericsson.com</email>
-	</address>
-	</author>
+        <organization>Ericsson</organization>
+        <address>
+         <postal>
+          <street>Magyar Tudosok krt. 11.</street>
+          <city>Budapest</city>
+          <country>Hungary</country>
+          <code>1117</code>
+         </postal>
+         <email>balazs.a.varga@ericsson.com</email>
+        </address>
+        </author>
 
     <author fullname="J&aacute;nos Farkas" initials="J." surname="Farkas">
       <organization>Ericsson</organization>
@@ -143,7 +143,7 @@
   <abstract>
    <t>
      This document specifies the MPLS Deterministic Networking data plane
-     operation and encapsulation over an IP network. The approach is modeled 
+     operation and encapsulation over an IP network. The approach is modeled
      on the operation of MPLS and PseudoWires (PW) over IP.
    </t>
   </abstract>
@@ -189,7 +189,7 @@
   </t>
  <t>
   These requirements are satisfied by the DetNet over MPLS Encapsulation
-  described in <xref target="I-D.ietf-detnet-mpls"/> and they are partly satisfied 
+  described in <xref target="I-D.ietf-detnet-mpls"/> and they are partly satisfied
   by the DetNet IP data plane defined in <xref target="I-D.ietf-detnet-ip"/>
  </t>
 </section>
@@ -208,11 +208,11 @@
    The following abbreviations are used in this document:
    <list style="hanging" hangIndent="14">
     <t hangText="d-CW">
-	  A DetNet Control Word (d-CW) is used for sequencing and identifying duplicate packets of a DetNet flow at the DetNet service
+          A DetNet Control Word (d-CW) is used for sequencing and identifying duplicate packets of a DetNet flow at the DetNet service
       sub-layer. </t>
     <t hangText="DetNet">Deterministic Networking.</t>
-    <t hangText="A-Label">A special case of an S-Label, whose properties are known only at 
-	   the aggregation and deaggregation end-points.</t>
+    <t hangText="A-Label">A special case of an S-Label, whose properties are known only at
+           the aggregation and deaggregation end-points.</t>
     <t hangText="F-Label">A Detnet "forwarding" label that identifies the LSP used to
     forward a DetNet flow across an MPLS PSN, e.g., a hop-by-hop
     label used between label switching routers.</t>
@@ -248,18 +248,18 @@
  <t>
   This document builds on the specification of MPLS over UDP defined
   in <xref target="RFC7510"/>.  It may replace partly or entirely the F-Label(s) used in <xref
-	  target="I-D.ietf-detnet-mpls"/> with UDP and IP headers.  The UDP and
+          target="I-D.ietf-detnet-mpls"/> with UDP and IP headers.  The UDP and
   IP header information is used to identify DetNet flows, including member
   flows, per <xref target="I-D.ietf-detnet-ip"/>. The resulting encapsulation
-  is shown in  <xref target="IP-encap-dn"/>. There may be zero or more F-label(s) 
+  is shown in  <xref target="IP-encap-dn"/>. There may be zero or more F-label(s)
   between the S-label and the UDP header.
  </t>
 
  <t>
-   Note that this encapsulation works equally well with IPv4, IPv6, and 
+   Note that this encapsulation works equally well with IPv4, IPv6, and
    IPv6-based Segment Routing <xref target="I-D.ietf-6man-segment-routing-header"/>.
  </t>
- 
+
  <figure title="UDP/IP Encapsulation of DetNet MPLS" anchor="IP-encap-dn">
  <artwork align="center"><![CDATA[
 +---------------------------------+
@@ -287,33 +287,33 @@
 
   <t>
     d-CW and and S-Labels are used as defined in <xref
-    target="I-D.ietf-detnet-mpls"/> and are not modified by this document. 
-	In case of aggregates the A-Label is treated as an S-Label and it is not 
-	modified as well.
+    target="I-D.ietf-detnet-mpls"/> and are not modified by this document.
+        In case of aggregates the A-Label is treated as an S-Label and it is not
+        modified as well.
   </t>
 </section>
 
 <section anchor="dp-procs" title="DetNet Data Plane Procedures">
   <t>
     To support outgoing DetNet MPLS over UDP/IP, an implementation MUST support the
-    provisioning of UDP/IP header information in addition or in place of 
-	F-Label(s).  
-	<!-- Note that multiple sets of F-Labels can be provisioned to
+    provisioning of UDP/IP header information in addition or in place of
+        F-Label(s).
+        <!-- Note that multiple sets of F-Labels can be provisioned to
     support PRF on transmitted DetNet MPLS flows and therefore, when PRF is
-    supported, multiple UDP/IP headers MAY be provisioned. 
+    supported, multiple UDP/IP headers MAY be provisioned.
   </t>
   <t>
-	[Note: PRF is an MPLS function. It produces member flows. Member flows have 
-	1to1 mapping to UDP/IP headers. So why are multiple headers provisioned? 
-	Delete next sentence?]
+        [Note: PRF is an MPLS function. It produces member flows. Member flows have
+        1to1 mapping to UDP/IP headers. So why are multiple headers provisioned?
+        Delete next sentence?]
   </t>
   <t>
-	When multiple
+        When multiple
     UDP/IP headers are provisioned for a particular outgoing DetNet IP flow, a
     copy of the outgoing packet, including the pushed S-Label (and optional F-label(s)), MUST be
-    made for each. 
-	-->
-	The headers for each outgoing packet MUST be based on
+    made for each.
+        -->
+        The headers for each outgoing packet MUST be based on
     the configuration information and as defined in <xref
     target="RFC7510"/>, with one exception.  The one exception is that
     the UDP Source Port value MUST be set to uniquely identify the
@@ -322,31 +322,31 @@
   </t>
 
 <!--  <t>
-  [Note: What about IPv4 Type of Service and IPv6 Traffic Class Fields? 
+  [Note: What about IPv4 Type of Service and IPv6 Traffic Class Fields?
   Do we intend to set them? 06.24: Yes, It is part of the IP header.]
   </t>  -->
 
   <t>
     To support receive processing an implementation MUST also support
-    the provisioning of received UDP/IP header information.  
+    the provisioning of received UDP/IP header information.
 <!--  </t>
   <t>
-	[Note: Are the receiving nodes T-PE nodes? Why? 06.24: No, they are not]
+        [Note: Are the receiving nodes T-PE nodes? Why? 06.24: No, they are not]
   </t>
-  <t>  
-	When
+  <t>
+        When
     S-Labels are taken from platform label space, all that is required
     is to provision that receiving UDP/IP encapsulated DetNet MPLS
     packets is permitted.  Once the UDP/IP header is stripped, the
     S-label uniquely identifies the app-flow.  When S-Labels are not
     taken from platform label space, UDP/IP header information MUST be
-    provisioned. --> 
-	The provisioned information MUST be used to
+    provisioned. -->
+        The provisioned information MUST be used to
     identify incoming app-flows based on the combination of S-Label and
     incoming IP/UDP header.  Normal receive processing, including PEF and POF
     can then take place.
   </t>
-    
+
  <!-- LB: I thought we agreed to pick one MPLS over IP encap.
       Also SR support can fall out of DetNet IP SR support once defined -->
 
@@ -358,7 +358,7 @@
             The following summarizes the set of information that is needed to
             configure DetNet MPLS over UDP/IP:
             <list style="symbols">
-			  <t>Label information (S-label or F-label) to be mapped to UDP/IP flow. </t>
+                          <t>Label information (S-label or F-label) to be mapped to UDP/IP flow. </t>
               <t>IPv4 and IPv6 source address field.</t>
               <t>IPv4 and IPv6 destination address field.</t>
               <t>IPv4 protocol field. Only UDP is allowed.</t>
@@ -394,7 +394,7 @@
   <t>
    The security considerations of DetNet in general are discussed in
    <xref target="I-D.ietf-detnet-architecture"/>
-   and <xref target="I-D.ietf-detnet-security"/>. MPLS and IP specific 
+   and <xref target="I-D.ietf-detnet-security"/>. MPLS and IP specific
    security considerations are described in <xref target="I-D.ietf-detnet-mpls"/>
    and <xref target="I-D.ietf-detnet-ip"/>. This draft does not have additional
    security considerations.
@@ -410,10 +410,10 @@
 
 <section anchor="acks" title="Acknowledgements">
       <t>
-		The authors wish to thank Pat Thaler, Norman Finn, Loa Anderson, David Black, 
-		Rodney Cummings, Ethan Grossman, Tal Mizrahi, David Mozes, Craig Gunther, 
-		George Swallow, Yuanlong Jiang and Carlos J. Bernardos for their
-		various contributions to this work.
+                The authors wish to thank Pat Thaler, Norman Finn, Loa Anderson, David Black,
+                Rodney Cummings, Ethan Grossman, Tal Mizrahi, David Mozes, Craig Gunther,
+                George Swallow, Yuanlong Jiang and Carlos J. Bernardos for their
+                various contributions to this work.
       </t>
 </section>
 

--- a/mpls-over-udp-ip/draft-ietf-detnet-mpls-over-udp-ip.xml
+++ b/mpls-over-udp-ip/draft-ietf-detnet-mpls-over-udp-ip.xml
@@ -1,44 +1,5 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
-<!ENTITY rfc2119 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
-<!ENTITY rfc3985 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3985.xml">
-<!ENTITY rfc4090 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4090.xml">
-<!ENTITY rfc4385 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4385.xml">
-<!ENTITY rfc4446 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4446.xml">
-<!ENTITY rfc4447 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4447.xml">
-<!ENTITY rfc4553 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4553.xml">
-<!ENTITY rfc4664 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4664.xml">
-<!ENTITY rfc4817 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4817.xml">
-<!ENTITY rfc5036 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5036.xml">
-<!ENTITY rfc5086 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5086.xml">
-<!ENTITY rfc5087 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5087.xml">
-<!ENTITY rfc5254 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5254.xml">
-<!ENTITY rfc5305 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5305.xml">
-<!ENTITY rfc5331 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5331.xml">
-<!ENTITY rfc5332 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5332.xml">
-<!ENTITY rfc5659 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5659.xml">
-<!ENTITY rfc5960 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5960.xml">
-<!ENTITY rfc6275 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6275.xml">
-<!ENTITY rfc6371 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6371.xml">
-<!ENTITY rfc6378 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6378.xml">
-<!ENTITY rfc6426 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6426.xml">
-<!ENTITY rfc6437 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6437.xml">
-<!ENTITY rfc6540 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6540.xml">
-<!ENTITY rfc6564 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6564.xml">
-<!ENTITY rfc6621 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6621.xml">
-<!ENTITY rfc6658 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6658.xml">
-<!ENTITY rfc6718 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6718.xml">
-<!ENTITY rfc6733 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6733.xml">
-<!ENTITY rfc7271 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7271.xml">
-<!ENTITY rfc7348 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7348.xml">
-<!ENTITY rfc7426 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7426.xml">
-<!ENTITY rfc7432 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7432.xml">
-<!ENTITY rfc7510 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7510.xml">
-<!ENTITY I-D.ietf-6man-segment-routing-header PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-6man-segment-routing-header">
-<!ENTITY I-D.ietf-detnet-problem-statement PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-problem-statement.xml">
-<!ENTITY I-D.ietf-detnet-architecture PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-architecture.xml">
-<!ENTITY I-D.ietf-mpls-residence-time SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-mpls-residence-time">
-
 ]>
 <!--
 - From 2/25 call:
@@ -286,10 +247,10 @@
  </artwork></figure>
 
   <t>
-    d-CW and and S-Labels are used as defined in <xref
+    d-CW, S-Labels and zero or more F-Labels are used as defined in <xref
     target="I-D.ietf-detnet-mpls"/> and are not modified by this document.
-        In case of aggregates the A-Label is treated as an S-Label and it is not
-        modified as well.
+    In case of aggregates the A-Label is treated as an S-Label and it
+    too is not modified.
   </t>
 </section>
 
@@ -313,12 +274,15 @@
     copy of the outgoing packet, including the pushed S-Label (and optional F-label(s)), MUST be
     made for each.
         -->
-        The headers for each outgoing packet MUST be based on
+        Multiple sets of header information MAY be needed when PRF is
+        supported for the MPLS flow.
+        The headers for each outgoing packet MUST be formatted on
     the configuration information and as defined in <xref
-    target="RFC7510"/>, with one exception.  The one exception is that
+    target="RFC7510"/>, with one exception.  Note that
     the UDP Source Port value MUST be set to uniquely identify the
     DetNet flow.  The packet MUST then be handed
     as a DetNet IP packet, per <xref target="I-D.ietf-detnet-ip"/>.
+    This includes QoS related traffic treatment.
   </t>
 
 <!--  <t>
@@ -343,7 +307,7 @@
     provisioned. -->
         The provisioned information MUST be used to
     identify incoming app-flows based on the combination of S-Label and
-    incoming IP/UDP header.  Normal receive processing, including PEF and POF
+    incoming IP/UDP header.  Normal receive processing as defined in <xref target="I-D.ietf-detnet-mpls"/>, including PEF and POF,
     can then take place.
   </t>
 
@@ -358,11 +322,16 @@
             The following summarizes the set of information that is needed to
             configure DetNet MPLS over UDP/IP:
             <list style="symbols">
-                          <t>Label information (S-label or F-label) to be mapped to UDP/IP flow. </t>
+                          <t>Label information (S-label or F-label) to
+                          be mapped to UDP/IP flow. Note that a single
+                          S-Label can map to multiple sets of UPD/IP
+                          information when PREOF is used.</t>
               <t>IPv4 and IPv6 source address field.</t>
               <t>IPv4 and IPv6 destination address field.</t>
+              <!-- 
               <t>IPv4 protocol field. Only UDP is allowed.</t>
               <t>IPv6 next header field. Only UDP is allowed.</t>
+               -->
               <t>IPv4 Type of Service and IPv6 Traffic Class Fields.</t>
               <t>UDP Source Port. </t>
               <t>UDP Destination Port. </t>
@@ -423,17 +392,17 @@
 
 <back>
   <references title="Normative References">
-   &rfc2119;
-   &rfc4385;
-   &rfc7510;
+   <?rfc include="reference.RFC.2119"?>
+   <?rfc include="reference.RFC.4385"?>
+   <?rfc include="reference.RFC.7510"?>
    <?rfc include="reference.RFC.8174"?>
    <?rfc include="reference.I-D.ietf-detnet-mpls'?>
    <?rfc include="reference.I-D.ietf-detnet-ip'?>
   </references>
   <references title="Informative References">
-   &rfc3985;
-&I-D.ietf-detnet-architecture;
-   &I-D.ietf-6man-segment-routing-header;
+   <?rfc include="reference.RFC.3985"?>
+   <?rfc include="reference.I-D.ietf-detnet-architecture"?>
+   <?rfc include="reference.I-D.ietf-6man-segment-routing-header"?>
    <?rfc include="reference.I-D.ietf-detnet-security"?>
   </references>
  </back>

--- a/mpls-over-udp-ip/draft-ietf-detnet-mpls-over-udp-ip.xml
+++ b/mpls-over-udp-ip/draft-ietf-detnet-mpls-over-udp-ip.xml
@@ -233,7 +233,7 @@
 +---------------------------------+    +--> DetNet data plane
 |             S-Label             |    |    MPLS encapsulation
 +---------------------------------+    |
-|          ( F-label(s) )         |    |
+|          [ F-label(s) ]         |    |
 +---------------------------------+ <--+
 |           UDP Header            |    |
 +---------------------------------+    +--> DetNet data plane
@@ -256,26 +256,12 @@
 
 <section anchor="dp-procs" title="DetNet Data Plane Procedures">
   <t>
-    To support outgoing DetNet MPLS over UDP/IP, an implementation MUST support the
-    provisioning of UDP/IP header information in addition or in place of
+    To support outgoing DetNet MPLS over UDP/IP encapsulation, an implementation MUST support the
+    provisioning of UDP and IP header information in addition or in place of
         F-Label(s).
-        <!-- Note that multiple sets of F-Labels can be provisioned to
-    support PRF on transmitted DetNet MPLS flows and therefore, when PRF is
-    supported, multiple UDP/IP headers MAY be provisioned.
-  </t>
-  <t>
-        [Note: PRF is an MPLS function. It produces member flows. Member flows have
-        1to1 mapping to UDP/IP headers. So why are multiple headers provisioned?
-        Delete next sentence?]
-  </t>
-  <t>
-        When multiple
-    UDP/IP headers are provisioned for a particular outgoing DetNet IP flow, a
-    copy of the outgoing packet, including the pushed S-Label (and optional F-label(s)), MUST be
-    made for each.
-        -->
-        Multiple sets of header information MAY be needed when PRF is
-        supported for the MPLS flow.
+    Note, when PRF is performed at the MPLS service sub-layer, there
+    will be multiple member flows, and each member flow will require the
+    provisioning of their own UDP and IP header information.
         The headers for each outgoing packet MUST be formatted on
     the configuration information and as defined in <xref
     target="RFC7510"/>, with one exception.  Note that
@@ -285,34 +271,14 @@
     This includes QoS related traffic treatment.
   </t>
 
-<!--  <t>
-  [Note: What about IPv4 Type of Service and IPv6 Traffic Class Fields?
-  Do we intend to set them? 06.24: Yes, It is part of the IP header.]
-  </t>  -->
-
   <t>
     To support receive processing an implementation MUST also support
-    the provisioning of received UDP/IP header information.
-<!--  </t>
-  <t>
-        [Note: Are the receiving nodes T-PE nodes? Why? 06.24: No, they are not]
-  </t>
-  <t>
-        When
-    S-Labels are taken from platform label space, all that is required
-    is to provision that receiving UDP/IP encapsulated DetNet MPLS
-    packets is permitted.  Once the UDP/IP header is stripped, the
-    S-label uniquely identifies the app-flow.  When S-Labels are not
-    taken from platform label space, UDP/IP header information MUST be
-    provisioned. -->
+    the provisioning of received UDP and IP header information.
         The provisioned information MUST be used to
     identify incoming app-flows based on the combination of S-Label and
-    incoming IP/UDP header.  Normal receive processing as defined in <xref target="I-D.ietf-detnet-mpls"/>, including PEF and POF,
+    incoming encapsulation header information.  Normal receive processing as defined in <xref target="I-D.ietf-detnet-mpls"/>, including PEF and POF,
     can then take place.
   </t>
-
- <!-- LB: I thought we agreed to pick one MPLS over IP encap.
-      Also SR support can fall out of DetNet IP SR support once defined -->
 
 </section>
 
@@ -328,10 +294,6 @@
                           information when PREOF is used.</t>
               <t>IPv4 and IPv6 source address field.</t>
               <t>IPv4 and IPv6 destination address field.</t>
-              <!-- 
-              <t>IPv4 protocol field. Only UDP is allowed.</t>
-              <t>IPv6 next header field. Only UDP is allowed.</t>
-               -->
               <t>IPv4 Type of Service and IPv6 Traffic Class Fields.</t>
               <t>UDP Source Port. </t>
               <t>UDP Destination Port. </t>
@@ -339,14 +301,6 @@
             This information MUST be provisioned per DetNet flow via
             configuration, e.g., via the controller or management plane.
           </t>
-<!--  06.24: there is an exact match  <t>
-            Information identifying a DetNet flow is ordered and
-            implementations use the first match.  This can, for example, be
-            used to provide a DetNet service for a specific UDP flow, with
-            unique Source and Destination Port field values, while
-            providing a different service for the aggregate of all other
-            flows with that same UDP Destination Port value.
-          </t>  -->
           <t>
             It is the responsibility of the DetNet controller plane to
             properly provision both flow identification information and

--- a/mpls-over-udp-ip/draft-ietf-detnet-mpls-over-udp-ip.xml
+++ b/mpls-over-udp-ip/draft-ietf-detnet-mpls-over-udp-ip.xml
@@ -105,7 +105,7 @@
    <t>
      This document specifies the MPLS Deterministic Networking data plane
      operation and encapsulation over an IP network. The approach is modeled
-     on the operation of MPLS and PseudoWires (PW) over IP.
+     on the operation of MPLS and over UDP/IP packet switched networks.
    </t>
   </abstract>
   </front>
@@ -129,8 +129,8 @@
   </t> -->
   <t>
   This document specifies use of the MPLS DetNet encapsulation over an IP network.
-  The approach is modeled on the operation of MPLS and PseudoWires (PW) over
-  an IP Packet Switched Network (PSN) <xref target="RFC3985"/><xref target="RFC4385"/><xref target="RFC7510"/>.
+  The approach is modeled on the operation of MPLS over
+  an IP Packet Switched Network (PSN) <xref target="RFC7510"/>.
   It maps the MPLS data plane encapsulation described in <xref
   target="I-D.ietf-detnet-mpls"/> to the DetNet IP data plane defined in <xref
   target="I-D.ietf-detnet-ip"/>.
@@ -183,7 +183,6 @@
     <t hangText="POF">Packet Ordering Function.</t>
     <t hangText="PRF">Packet Replication Function.</t>
     <t hangText="PSN">Packet Switched Network.</t>
-    <t hangText="PW">PseudoWire.</t>
     <t hangText="S-Label">A DetNet "service" label that is used between DetNet
     nodes that implement also the DetNet service sub-layer functions. An S-Label is
     also used to identify a DetNet flow at DetNet service sub-layer.</t>
@@ -347,14 +346,12 @@
 <back>
   <references title="Normative References">
    <?rfc include="reference.RFC.2119"?>
-   <?rfc include="reference.RFC.4385"?>
    <?rfc include="reference.RFC.7510"?>
    <?rfc include="reference.RFC.8174"?>
    <?rfc include="reference.I-D.ietf-detnet-mpls'?>
    <?rfc include="reference.I-D.ietf-detnet-ip'?>
   </references>
   <references title="Informative References">
-   <?rfc include="reference.RFC.3985"?>
    <?rfc include="reference.I-D.ietf-detnet-architecture"?>
    <?rfc include="reference.I-D.ietf-6man-segment-routing-header"?>
    <?rfc include="reference.I-D.ietf-detnet-security"?>

--- a/mpls/draft-ietf-detnet-mpls.xml
+++ b/mpls/draft-ietf-detnet-mpls.xml
@@ -189,8 +189,8 @@
      </t>
 
      <t hangText="A-Label">
-       A special case of an S-Label, whose properties are known only at
-           the aggregation and deaggregation end-points.
+       A special case of an S-Label, whose aggregation properties are known only at 
+       the aggregation and deaggregation end-points.
      </t>
 
     <t hangText="d-CW">
@@ -339,7 +339,7 @@ End System        Node         Node           Node        End System
       <t>
         DetNet end system and relay nodes understand the particular needs
         of DetNet flows and provide both DetNet service and forwarding
-        sub-layer functions.  In the case of MPLS, DetNet nodes add, remove
+        sub-layer functions.  In the case of MPLS, DetNet service-aware nodes add, remove
         and process d-CWs, S-Labels and F-labels as needed.
         DetNet MPLS nodes provide functionality analogous to T-PEs when
         they sit at the edge of an MPLS domain, and S-PEs when they are
@@ -491,7 +491,7 @@ DFx = DetNet member flow x over a TE LSP
     </list>
    </t>
 
-  <figure title="Encapsulation of a DetNet App-Flow in an MPLS(-TP) PSN" anchor="fig_pw_mpls">
+  <figure title="Encapsulation of a DetNet App-Flow in an MPLS PSN" anchor="fig_pw_mpls">
   <artwork align="center"><![CDATA[
   DetNet MPLS-based encapsulation
 
@@ -553,7 +553,7 @@ DFx = DetNet member flow x over a TE LSP
      <t>16 bits</t>
      <t>28 bits</t>
    </list>
-   The sequence number length MUST be provisioned (configured) on a per
+   The sequence number length MUST be provisioned on a per
    app-flow basis via
    configuration, e.g., the controller plane described in
    <xref target="I-D.ietf-detnet-data-plane-framework"/>.
@@ -569,7 +569,7 @@ DFx = DetNet member flow x over a TE LSP
     When the sequence number field length is 16 or 28 bits for a flow,
     the sequence number MUST be incremented by one for each new app-flow
     packet sent. When the field length is 16 bits, d-CW bits 4 to 15
-    MUST be set to zero (0). This values carried in this field can wrap
+    MUST be set to zero (0). The values carried in this field can wrap
     and it is important to note that zero (0) is a valid field value.
     For example, were the sequence number size is 16 bits, the sequence
     will contain: 65535, 0, 1. In this case, zero (0) is an ordinary
@@ -586,10 +586,9 @@ DFx = DetNet member flow x over a TE LSP
   <section anchor="flow-identification" title="S-Labels">
    <t>
     App-flow identification at a DetNet service sub-layer is realized by
-    an S-Label.  Each app-flow MUST be sent by the node that adds a d-CW
-    with a single specific S-Label value.  MPLS-aware DetNet end systems
+    an S-Label.  MPLS-aware DetNet end systems
     and edge nodes, which are by definition MPLS ingress and egress
-    nodes, MUST add and remove the d-CW and S-Label.  Relay nodes MAY
+    nodes, MUST add and remove an app-flow specific d-CW and S-Label.  Relay nodes MAY
     swap S-Label values when processing an app-flow.
    </t>
    <t>
@@ -632,12 +631,13 @@ DFx = DetNet member flow x over a TE LSP
      the app-flow associated with the incoming packet based on the
      S-Label.  When a node is using platform labels for S-Labels, no
      additional information is needed as the S-label uniquely identifies
-     the app-flow.  In the case where platform labels are not used, one
-     or more F-Labels proceeding the S-Label MUST be used together with
-     the S-Label to uniquely identify the incoming app-flows. When PHP
-     is used, the incoming interface MAY also be used to together with
+     the app-flow.  In the case where platform labels are not used, zero
+     or more F-Labels and optionally, the incoming interface, proceeding the S-Label MUST be used together with
+     the S-Label to uniquely identify the app-flows associated with a
+     received packet.
+     The incoming interface MAY also be used to together with
      any present F-Label(s) and the S-Label to uniquely identify an
-     incoming app-flows.  Note that choice to use platform label space
+     incoming app-flows, for example, to in the case where PHP is used.  Note that choice to use platform label space
      for S-Label or S-Label plus one or more F-Labels to identify app
      flows is a local implementation choice, with one caveat.  When one
      or more F-labels, or incoming interface, is needed together with an
@@ -663,7 +663,7 @@ DFx = DetNet member flow x over a TE LSP
      <t>
        After an app-flow is identified for a received DetNet MPLS
        packet, as described above, an implementation MUST check if PEF
-       is configured for that app-flow.  When configured the
+       is configured for that app-flow.  When configured, the
        implementation MUST track the sequence number contained in
        received d-CWs and MUST ensure that duplicate (replicated)
        instances of a particular sequence number are discarded.  The
@@ -697,7 +697,7 @@ DFx = DetNet member flow x over a TE LSP
      <t>
        After an app-flow is identified for a received DetNet MPLS
        packet, as described above, an implementation MUST check if POF
-       is configured for that app-flow.  When configured the
+       is configured for that app-flow.  When configured, the
        implementation MUST track the sequence number contained in
        received d-CWs and MUST ensure that packets are processed in the
        order indicated in the received d-CW sequence number field, which
@@ -754,7 +754,7 @@ DFx = DetNet member flow x over a TE LSP
        is supported, the same app-flow data will be sent over multiple
        outgoing forwarding sub-layer LSPs. To support PRF an
        implementation MUST support the setting of different sets of
-       F-Labels. Therefore, to allow for the omission of F-Labels,
+       F-Labels. To allow for the omission of F-Labels,
        an implementation SHOULD also allow multiple outgoing interfaces
        to be provisioned.  PRF MUST NOT be used with app-flows configured
        with a d-CW sequence number field length of 0 bits.
@@ -783,9 +783,8 @@ DFx = DetNet member flow x over a TE LSP
        on the S-Label.  When a node is using platform labels for
        S-Labels, any F-Labels can be popped and the S-label uniquely
        identifies the app-flow.  In the case where platform labels are
-       not used, F-Label(s) MUST also be provisioned for incoming
-       app-flows. When PHP is used, incoming interface MUST be
-       provisioned.  The provisioned information MUST then be used to
+       not used, F-Label(s) and, optionally, the incoming interface MUST also be provisioned for incoming
+       app-flows.  The provisioned information MUST then be used to
        identify incoming app-flows based on the combination of S-Label
        and F-Label(s) or incoming interface.
      </t>
@@ -797,7 +796,7 @@ DFx = DetNet member flow x over a TE LSP
          the service requirements of the DetNet flow or flows carried in
          the LSPs represented by the F-Labels.  This includes normal
          push, pop and swap operations.  Such processing is essentially
-         the same type of processing enabled for TE LSPs, although the
+         the same type of processing provided for TE LSPs, although the
          specific service parameters, or traffic specification, can
          differ.  When the DetNet service parameters of the app-flow or
          flows carried in an LSP represented by an F-Label can be met by
@@ -830,21 +829,20 @@ DFx = DetNet member flow x over a TE LSP
          provisioned with a service parameters that dictates the
          specific traffic treatment to be received by the traffic
          carried over that LSP.  Implementations of this document MUST
-         ensure that traffic carried over each LSP represented by an
-         F-Label receives the traffic treatment provisioned for that
+         ensure that traffic carried over each LSP represented by one or more
+         F-Labels receives the traffic treatment provisioned for that
          LSP.  Typical mechanisms used to provide different treatment to
          different flows includes the allocation of system resources
          (such as queues and buffers) and provisioning or related
          parameters (such as shaping, and policing). Support can also be
          provided via an underlying network technology such IEEE802.1
          TSN <xref target="I-D.ietf-detnet-mpls-over-tsn"/>.
-         Other than in the TSN case,
-         the specific mechanisms used by a DetNet node to ensure DetNet
+         The specific mechanisms used by a DetNet node to ensure DetNet
          service delivery requirements are met for supported DetNet
          flows is outside the scope of this document.
        </t>
        <t>
-         Packets that are marked in a way that does not correspond to
+         Packets that are marked in a way that do not correspond to
          allocated resources, e.g., lack a provisioned F-Label, can
          disrupt the QoS offered to properly reserved DetNet flows by
          using resources allocated to the reserved flows.  Therefore,
@@ -915,8 +913,8 @@ DFx = DetNet member flow x over a TE LSP
    <t>
     The resource control and management aspects of aggregation
     (including the configuration of queuing, shaping, and policing) are
-    the responsibility of the DetNet controller plane and will be covered in
-    other documents.  It is also the responsibility of the controller
+    the responsibility of the DetNet controller plane and is out of scope of this
+    documents.  It is also the responsibility of the controller
     plane to ensure that consistent aggregation methods are used.
    </t>
    <section anchor="aggregation-at-the-lsp" title="Aggregation Via LSP Hierarchy">
@@ -977,7 +975,7 @@ DFx = DetNet member flow x over a TE LSP
 ]]></artwork></figure>
 
     <t>
-     Both the aggregation label, or A-Label, and the individual flow's S-Label
+     Both the aggregation label, which is referred to as an A-Label, and the individual flow's S-Label
      have their MPLS S bit
      set indicating bottom of stack, and the d-CW allows the PREOF
      to work.  An A-Label is a special case of an S-Label, whose
@@ -1151,39 +1149,18 @@ DFx = DetNet member flow x over a TE LSP
 
 <!-- ===================================================================== -->
 
-<section anchor="mpls-flow-id-info"
+<section anchor="mc_summary"
          title="Management and Control Information Summary">
-         <t>
-     The following summarizes the set of information that is needed to
-     identify an individual and aggregated DetNet flow for service sub-layer aware nodes:
-     <list style="symbols">
-       <t>Each flow's service parameters and S-Label.</t>
-       <t>The PREOF functions to be supported
-       for each S-Label.</t>
-       <t>The mapping of each S-Label to an
-       F-Label stack.</t>
-       <t>S-Labels to A-Label mappings.</t>
-       <t>A-Label values and service parameters.</t>
-     </list>
-  </t>
   <t>
-     The following summarizes the set of information that is needed to
-     for forwarding sub-layer aware nodes:
-     <list style="symbols">
-       <t>Each DetNet F-Label value and associated traffic parameters.</t>
-       <t>F-Label to H-LSP mappings.</t>
-       <t>H-LSP label values and associated parameters.</t>
-       <t>Outgoing interface, next hop, and sub-network parameters on a technology
-       specific basis.</t>
-     </list>
+    The specific information needed for the processing of each DetNet
+    service depends on the DetNet node type and the functions being
+    provided on the node.  This section summarizes based on the DetNet
+    sub-layer and if the DetNet traffic is being sent or received.  All
+    DetNet node types are DetNet forwarding sub-layer aware, while all
+    but transit nodes are service sub-layer aware.  This is shown in <xref
+    target="fig_dn_mpls_detnet"/>. 
   </t>
-  <t>
-    It is the responsibility of the DetNet controller plane to
-    properly provision both flow identification information and
-    the flow specific resources needed to provided the traffic
-    treatment needed to meet each flow's service requirements.
-    This applies for aggregated and individual flows.
-  </t>
+  <!-- LB: this seems duplicative
         <t>
         For DetNet management there are a number of approaches that could be used to provide
         explicit routes and resource allocation in the MPLS forwarding sub-layer:
@@ -1203,8 +1180,9 @@ DFx = DetNet member flow x over a TE LSP
             allocation.
           </t>
         </list>
-      </t>
-         <t>
+        </t>
+  -->        
+  <t>
         Much like other MPLS labels, there are a number of alternatives
         available for DetNet S-Label and F-Label advertisement to an
         upstream peer node. These include distributed signaling
@@ -1216,8 +1194,150 @@ DFx = DetNet member flow x over a TE LSP
         space are out of scope of this document.
         There are particular DetNet considerations and requirements that
         are discussed in <xref target="I-D.ietf-detnet-data-plane-framework"/>.
+  </t>
+  <section anchor="mc_summary_ssl"
+         title="Service Sub-Layer Information Summary">
+  <t>
+    The following summarizes the information that is needed on service
+    sub-layer aware nodes that send DetNet MPLS traffic, on a per
+    service basis:
+    <list style="symbols">
+      <t>
+        App-Flow identification information, e.g., an incoming
+        service on a relay node or IP information as defined in <xref
+        target="I-D.ietf-detnet-ip-over-mpls"/>.
       </t>
+      <t>
+        The sequence number length to be used for the service.  Valid
+        values included 0, 16 and 28 bits. 0 bits cannot be used when
+        PRF is configured for the service.
+      </t>
+      <t>
+        The S-Label for the service.
+      </t>
+      <t>
+        If PRF is to be provided for the service.
+      </t>
+      <t>
+        The forwarding sub-layer information associated with the output
+        of the service sub-layer.  Note that when the PRF function is
+        provisioned, this information is per DetNet member flow.
+        Logically this is a pointer to details provided below for
+        transmission of Detnet flows at the forwarding sub-layer.
+      </t>
+    </list>
+  </t>
+  <t>
+    The following summarizes the information that is needed on service
+    sub-layer aware nodes that receives DetNet MPLS traffic, on a per
+    service basis:
+    <list style="symbols">
+      <t>
+        The forwarding sub-layer information associated with the input
+        of the service sub-layer.  Note that when the PEF function is
+        provisioned, this information is per DetNet member flow.
+        Logically this is a pointer to details provided below related to
+        the reception of Detnet flows at the forwarding sub-layer or
+        A-Label.
+      </t>
+      <t>
+        The S-Label for the received service.
+      </t>
+      <t>
+        If PEF or POF is to be provided for the service.
+      </t>
+      <t>
+        The sequence number length to be used for the service.  Valid
+        values included 0, 16 and 28 bits. 0 bits cannot be used when
+        PEF or POF are configured for the service.
+      </t>
+    </list>
+  </t>
+  <section anchor="mc_summary_ssl_agg"
+         title="Service Aggregation Information Summary">
+    <t>
+      Nodes performing aggregation using A-Labels, per Section <xref
+      target="aggregating-detnet-flows-as-a-new-detnet-flow"/>, require
+      the additional information summarized in this section.
+    </t>
+    <t>
+      The following summarizes the information that is needed on
+      a node that sends aggregated flows using A-Labels:
+      <list style="symbols">
+        <t>
+          The S-Labels or F-Labels that are to be carried over each
+          aggregated service.
+        </t>
+        <t>The A-Label associated with each aggregated service.</t>
+        <t>The other S-Label information summarized above.</t>
+     </list>
+    </t>
+    <t>
+      On the receiving node, the A-Label provides the forwarding context
+      of an incoming interface or an F-Label and is used in subsequent
+      service or forwarding sub-layer receive processing, as
+      appropriated.  The related addition configuration that may be
+      provided discussed elsewhere in this section.
+    </t>
+  </section>
+  </section>
+  <section anchor="mc_summary_fsl"
+         title="Forwarding Sub-Layer Information Summary">
+    <t>
+      The following summarizes the information that is needed on
+      forwarding sub-layer aware nodes that send DetNet MPLS traffic, on
+      a per forwarding sub-layer flow basis:
+      <list style="symbols">
+        <t>
+          The outgoing F-Label stack to be pushed. The stack may include
+          H-LSP labels.
+        </t>
+        <t>
+          The traffic parameters associated with a specific label in
+          the stack.  Note that there may be multiple sets of traffic
+          paramters associated with specific labels in the stack, e.g.,
+          when H-LSPs are used.
+        </t>
+        <t>
+          Outgoing interface and, for unicast traffic, the next hop
+          information.
+        </t>
+        <t>
+          Sub-network specific parameters on a technology specific
+          basis. For example, see <xref
+          target="I-D.ietf-detnet-mpls-over-tsn"/>.
+        </t>
+      </list>
+    </t>
+    <t>
+      The following summarizes the information that is needed on
+      forwarding sub-layer aware nodes that receive DetNet MPLS traffic, on
+      a per forwarding sub-layer flow basis:
+      <list style="symbols">
+        <t>
+          The incoming interface.  For some implementations and
+          deployment scenarios, this information may not be needed.
+        </t>
+        <t>
+          The incoming F-Label stack to be popped. The stack may include
+          H-LSP labels.
+        </t>
+        <t>
+          How the incoming forwarding sub-layer flow is to be handled,
+          i.e., forwarded as a transit node, or provided to the service
+          sub-layer. 
+        </t>
+      </list>
+    </t>
+  <t>
+    It is the responsibility of the DetNet controller plane to
+    properly provision both flow identification information and
+    the flow specific resources needed to provided the traffic
+    treatment needed to meet each flow's service requirements.
+    This applies for aggregated and individual flows.
+  </t>
 
+  </section>
 </section>
 <!-- ===================================================================== -->
 
@@ -1327,10 +1447,10 @@ DFx = DetNet member flow x over a TE LSP
    <?rfc include="reference.RFC.6790"?>
    <?rfc include="reference.I-D.ietf-detnet-security"?>
    <?rfc include="reference.I-D.ietf-detnet-architecture"?>
-
+   <?rfc include="reference.I-D.ietf-detnet-data-plane-framework"?>
+   <?rfc include="reference.I-D.ietf-detnet-ip-over-mpls"?>
+   <?rfc include="reference.I-D.ietf-detnet-mpls-over-tsn"?>
    <?rfc include="reference.I-D.ietf-spring-segment-routing-mpls'?>
-   <?rfc include="reference.I-D.ietf-detnet-data-plane-framework'?>
-   <?rfc include="reference.I-D.ietf-detnet-mpls-over-tsn'?>
    <reference anchor="IEEE802.1AE-2018"
       target="https://ieeexplore.ieee.org/document/8585421">
       <front>

--- a/mpls/draft-ietf-detnet-mpls.xml
+++ b/mpls/draft-ietf-detnet-mpls.xml
@@ -555,7 +555,7 @@ DFx = DetNet member flow x over a TE LSP
    </list>
    The sequence number length MUST be provisioned on a per
    app-flow basis via
-   configuration, e.g., the controller plane described in
+   configuration, i.e., via the controller plane described in
    <xref target="I-D.ietf-detnet-data-plane-framework"/>.
   </t>
   <t>
@@ -572,10 +572,13 @@ DFx = DetNet member flow x over a TE LSP
     MUST be set to zero (0). The values carried in this field can wrap
     and it is important to note that zero (0) is a valid field value.
     For example, were the sequence number size is 16 bits, the sequence
-    will contain: 65535, 0, 1. In this case, zero (0) is an ordinary
-    sequence number. This differs from <xref target="RFC4448"/> where a
-    sequence number of zero (0) does not indicate that no sequence
-    number field value is in use.
+    will contain: 65535, 0, 1, where zero (0) is an ordinary
+    sequence number.
+  </t>
+  <t>
+    It is important to note that this document differs from <xref
+    target="RFC4448"/> where a sequence number of zero (0) is used to
+    indicate that the sequence number check algorithm is not used.
   </t>
   <t>
     The sequence number is optionally used during receive processing as
@@ -736,17 +739,16 @@ DFx = DetNet member flow x over a TE LSP
           the following procedures apply.
        </t>
        <t>
-         When sending a DetNet flow, Zero or more F-Labels MAY be added
+         When sending a DetNet flow, zero or more F-Labels MAY be pushed
          on top of an S-Label by the node pushing an S-Label. The
          F-Labels to be pushed when sending a particular app-flow MUST
          be provisioned per app-flow via configuration, e.g., via the
          controller plane discussed in
          <xref target="I-D.ietf-detnet-data-plane-framework"/>.
          F-Labels can also provide context for an S-Label.
-
          To
          allow for the omission of F-Labels, an implementation SHOULD
-         also allow an outgoing interface to be provisioned.
+         also allow an outgoing interface to be used.
      </t>
      <t>
        The Packet Replication Function (PRF) function MAY be supported
@@ -819,7 +821,7 @@ DFx = DetNet member flow x over a TE LSP
          outgoing interfaces, a next hop LSR.  Note that this
          information MUST be provisioned via configuration or the
          controller plane.  In the previously mentioned special case
-         where there is no added F-labels and the outgoing interface is
+         where there are no added F-labels and the outgoing interface is
          not a point-to-point interface, the outgoing interface MUST
          also be associated with a next hop LSR.
        </t>
@@ -1016,6 +1018,8 @@ DFx = DetNet member flow x over a TE LSP
      die during a transient loop, but given the sensitivity of applications
      to packet latency the impact on the DetNet application would be
      severe.
+     To avoid the problem of a transient forwarding loop, changes to an
+     LSP supporting DetNet MUST be loop-free.
    </t>
 
    <section title="Edge Node Processing" anchor="sec_t_pe">

--- a/mpls/draft-ietf-detnet-mpls.xml
+++ b/mpls/draft-ietf-detnet-mpls.xml
@@ -34,17 +34,17 @@
      DetNet Data Plane: MPLS</title>
 
   <author role="editor" fullname="Bal&aacute;zs Varga" initials="B." surname="Varga">
-	<organization>Ericsson</organization>
-	<address>
-	 <postal>
-	  <street>Magyar Tudosok krt. 11.</street>
-	  <city>Budapest</city>
-	  <country>Hungary</country>
-	  <code>1117</code>
-	 </postal>
-	 <email>balazs.a.varga@ericsson.com</email>
-	</address>
-	</author>
+        <organization>Ericsson</organization>
+        <address>
+         <postal>
+          <street>Magyar Tudosok krt. 11.</street>
+          <city>Budapest</city>
+          <country>Hungary</country>
+          <code>1117</code>
+         </postal>
+         <email>balazs.a.varga@ericsson.com</email>
+        </address>
+        </author>
 
     <author fullname="J&aacute;nos Farkas" initials="J." surname="Farkas">
       <organization>Ericsson</organization>
@@ -129,7 +129,7 @@
   </t>
   <t>
     The DetNet Architecture models the DetNet related data plane functions
-    decomposed 
+    decomposed
     into two sub-layers: a service sub-layer and a forwarding sub-layer.  The
     service sub-layer is used to provide DetNet service functions such as
     protection and reordering.  The forwarding sub-layer is used to provide
@@ -144,7 +144,7 @@
     be carried over a variety of different network technologies that can
     provide the DetNet required level of service.  However, the specific
     details of how DetNet MPLS is carried over different network technologies
-    is out of scope of this document.  
+    is out of scope of this document.
   </t>
   <t>
     MPLS encapsulated DetNet flows can carry different types of
@@ -153,10 +153,10 @@
     using DetNet MPLS sub-networks can be found in
     [I-D.ietf-detnet-ip].  DetNet MPLS may use an associated controller
     and Operations, Administration, and Maintenance (OAM) functions
-    that are defined outside of this document. 
+    that are defined outside of this document.
   </t>
   <t>
-    Important background information common to all data planes for DetNet 
+    Important background information common to all data planes for DetNet
     can be found in the DetNet Data
     Plane Framework <xref target="I-D.ietf-detnet-data-plane-framework"/>.
   </t>
@@ -189,8 +189,8 @@
      </t>
 
      <t hangText="A-Label">
-       A special case of an S-Label, whose properties are known only at 
-	   the aggregation and deaggregation end-points.
+       A special case of an S-Label, whose properties are known only at
+           the aggregation and deaggregation end-points.
      </t>
 
     <t hangText="d-CW">
@@ -247,7 +247,7 @@
     by DetNet.  A straight forward approach utilizing MPLS for a
     DetNet service sub-layer is based on the existing pseudowire (PW)
     encapsulations and by utilizing existing MPLS Traffic Engineering
-    encapsulations and mechanisms.  
+    encapsulations and mechanisms.
     Background on PWs can be found in <xref target="RFC3985"/> and <xref
     target="RFC3031"/>. Background on MPLS Traffic Engineering can be
     found in <xref target="RFC3272"/> and <xref target="RFC3209"/>.
@@ -271,13 +271,13 @@ Top of Stack         .
   </figure>
 
   <t>
-    The DetNet MPLS data plane representation is illustrated in 
-    <xref target="dn_mpls_dp_approach"/>. 
+    The DetNet MPLS data plane representation is illustrated in
+    <xref target="dn_mpls_dp_approach"/>.
     The service sub-layer includes a DetNet control word (d-CW) and
     a identifying service label (S-Label).  The DetNet control word
     (d-CW) conforms to the Generic PW MPLS Control Word (PWMCW)
-    defined in <xref target="RFC4385"/>. An aggregation label (A-Label) is 
-    a special case of S-Label used for aggregation. 
+    defined in <xref target="RFC4385"/>. An aggregation label (A-Label) is
+    a special case of S-Label used for aggregation.
   </t>
 
   <t>
@@ -285,9 +285,9 @@ Top of Stack         .
     sub-layer,uses the local context associated with that S-Label,
     provided by a received F-Label, to determine what local DetNet
     operation(s) are applied to that packet.
-    An S-Label may be taken from the platform label space 
-    <xref target="RFC3031"/>, making it unique, enabling DetNet 
-    flow identification regardless of which input interface or 
+    An S-Label may be taken from the platform label space
+    <xref target="RFC3031"/>, making it unique, enabling DetNet
+    flow identification regardless of which input interface or
     LSP the packet arrives on.
   </t>
 
@@ -296,9 +296,9 @@ Top of Stack         .
     forwarding labels (F-Labels). MPLS Traffic Engineering
     encapsulations and mechanisms can be utilized to provide a
     forwarding sub-layer that is responsible for providing resource
-    allocation and explicit routes. 
+    allocation and explicit routes.
   </t>
-  
+
   </section>
 
   <section title="DetNet MPLS Data Plane Scenarios"
@@ -329,7 +329,7 @@ End System        Node         Node           Node        End System
         ]]></artwork>
       </figure>
       <t>
-        <xref target="fig_dn_mpls_detnet"/> illustrates 
+        <xref target="fig_dn_mpls_detnet"/> illustrates
         a hypothetical DetNet MPLS-only network
         composed of DetNet aware MPLS enabled end systems, operating over a
         DetNet aware MPLS network.  In this figure, the relay nodes are PE
@@ -337,14 +337,14 @@ End System        Node         Node           Node        End System
         are LSRs.
       </t>
       <t>
-	DetNet end system and relay nodes understand the particular needs
+        DetNet end system and relay nodes understand the particular needs
         of DetNet flows and provide both DetNet service and forwarding
         sub-layer functions.  In the case of MPLS, DetNet nodes add, remove
         and process d-CWs, S-Labels and F-labels as needed.
         DetNet MPLS nodes provide functionality analogous to T-PEs when
         they sit at the edge of an MPLS domain, and S-PEs when they are
         in the middle of an MPLS domain, see <xref
-        target="RFC6073"/>. 
+        target="RFC6073"/>.
       </t>
       <t>
         In a DetNet MPLS network, transit nodes may be DetNet service
@@ -353,7 +353,7 @@ End System        Node         Node           Node        End System
         special requirements of the DetNet service sub-layer, but would
         still provide traffic engineering functions and the QoS
         capabilities needed to ensure that the (TE) LSPs meet the service
-        requirements of the carried DetNet flows.  
+        requirements of the carried DetNet flows.
       </t>
 
       <t>
@@ -392,14 +392,14 @@ System  |    +--------+       +--------+       +--------+   | System
 |CE1|========|    \   |       |   X    |       |   /    |======|CE2|
 |   |   |    |     \_.|..DF2..|._/ \__.|..DF4..|._/     |   |  |   |
 +---+        |        |=======|        |=======|        |      +---+
-    ^        +--------+       +--------+       +--------+      ^ 
+    ^        +--------+       +--------+       +--------+      ^
     |        Relay Node       Relay Node       Relay Node      |
     |          (S-PE)           (S-PE)           (S-PE)        |
     |                                                          |
     |<---------------------- DetNet MPLS --------------------->|
     |                                                          |
     |<--------------- End to End DetNet Service -------------->|
-    
+
     -------------------------- Data Flow ------------------------->
 
 X   = Optional service protection (none, PRF, PREOF, PEF/POF)
@@ -430,10 +430,10 @@ DFx = DetNet member flow x over a TE LSP
   </t>
   <t>
    In this design an MPLS service label (the S-Label), similar to a
-   pseudowire (PW) label <xref target="RFC3985"/>, 
+   pseudowire (PW) label <xref target="RFC3985"/>,
    is used to identify both the
    DetNet flow identity and the payload MPLS payload type satisfying
-   (1) and (2) in the list above.  
+   (1) and (2) in the list above.
    OAM traffic discrimination
    happens through the use of the Associated Channel method described in
    <xref target="RFC4385"/>.  The DetNet sequence number is carried in
@@ -448,22 +448,22 @@ DFx = DetNet member flow x over a TE LSP
   <t>
    The LSP used to forward the DetNet packet may be of any type
    (MPLS-LDP, MPLS-TE, MPLS-TP <xref target="RFC5921"/>,  or MPLS-SR
-   <xref target="I-D.ietf-spring-segment-routing-mpls"/>).  
+   <xref target="I-D.ietf-spring-segment-routing-mpls"/>).
    The LSP (F-Label) label
    and/or the S-Label may be used to indicate the queue processing as
    well as the forwarding parameters.  Note that the possible use of
    Penultimate Hop Popping (PHP) means that the S-Label may be the
-   only label received at the terminating DetNet service. 
+   only label received at the terminating DetNet service.
   </t>
  </section>
 
   <section title="MPLS Data Plane Encapsulation" anchor="pwSolution">
    <t>
     <xref target="fig_pw_mpls"/> illustrates a DetNet data plane MPLS
-    encapsulation.  The MPLS-based encapsulation of the DetNet flows 
-    is well suited for the scenarios described in 
+    encapsulation.  The MPLS-based encapsulation of the DetNet flows
+    is well suited for the scenarios described in
     <xref target="I-D.ietf-detnet-data-plane-framework"/>.
-    Furthermore, an end to end DetNet 
+    Furthermore, an end to end DetNet
     service i.e., native DetNet deployment (see <xref
     target="sec_mpls_dt_dp_scen"/>) is also possible if DetNet end
     systems are capable of initiating and termination MPLS encapsulated
@@ -545,7 +545,7 @@ DFx = DetNet member flow x over a TE LSP
     </list>
   </t>
   <t>
-   A separate sequence number space MUST be maintained by 
+   A separate sequence number space MUST be maintained by
    the node that adds the d-CW for each DetNet app-flow.
    The following sequence number field lengths MUST be supported:
    <list style="bullets">
@@ -595,7 +595,7 @@ DFx = DetNet member flow x over a TE LSP
    <t>
     The S-Label value MUST be provisioned per app-flow via
     configuration, e.g., via
-    the controller plane described in 
+    the controller plane described in
     <xref target="I-D.ietf-detnet-data-plane-framework"/>.
     Note that S-Labels provide app-flow identification at the downstream
     DetNet service sub-layer receiver, not the sender.  As such,
@@ -605,13 +605,13 @@ DFx = DetNet member flow x over a TE LSP
     Because S-Labels are local to each node rather than being a
     global identifier within a domain, they must be advertised to their
     upstream DetNet service-aware peer nodes (e.g., a DetNet MPLS End
-    System or a DetNet Relay or Edge Node and interpreted in the 
+    System or a DetNet Relay or Edge Node and interpreted in the
     context of their received F-Label.
    </t>
    <t>
     The S-Label will normally be at the bottom of the label stack once
-    the last F-Label is removed, immediately preceding the d-CW.  
-    To support service sub-layer level OAM, an OAM Associated Channel 
+    the last F-Label is removed, immediately preceding the d-CW.
+    To support service sub-layer level OAM, an OAM Associated Channel
     Header (ACH) <xref target="RFC4385"/>
     together with a Generic Associated Channel Label (GAL) <xref
     target="RFC5586"/> MAY be used in place of a d-CW.
@@ -649,7 +649,7 @@ DFx = DetNet member flow x over a TE LSP
    <t>
      The use of platform labels for S-Labels matches other pseudowire
      encapsulations for consistency but there is no hard requirement in
-     this regard.  
+     this regard.
    </t>
    <section anchor="pef-requirements" title="Packet Elimination Function
                                              Processing">
@@ -657,11 +657,11 @@ DFx = DetNet member flow x over a TE LSP
        Implementations MAY support the Packet Elimination Function (PEF)
        for received DetNet MPLS flows.  When supported, use of the PEF
        for a particular app-flow MUST be provisioned via configuration,
-       e.g., via the controller plane described in 
+       e.g., via the controller plane described in
        <xref target="I-D.ietf-detnet-data-plane-framework"/>.
      </t>
      <t>
-       After an app-flow is identified for a received DetNet MPLS 
+       After an app-flow is identified for a received DetNet MPLS
        packet, as described above, an implementation MUST check if PEF
        is configured for that app-flow.  When configured the
        implementation MUST track the sequence number contained in
@@ -688,7 +688,7 @@ DFx = DetNet member flow x over a TE LSP
        (POF).  Implementations MAY support POF. When
        supported, use of the POF for a particular app-flow MUST be
        provisioned via configuration, e.g., via the controller plane
-       described by 
+       described by
        <xref target="I-D.ietf-detnet-data-plane-framework"/>.
        Implementations MAY required that PEF and POF be used in combination.
        There is no requirement related to the order of execution of the Packet
@@ -726,7 +726,7 @@ DFx = DetNet member flow x over a TE LSP
      </t>
      <section anchor="f-labels-ssl"
               title="Service Sub-Layer and Packet Replication Function Processing">
-       
+
        <t>
           DetNet MPLS end systems, edge nodes and relay nodes may operate at
           the DetNet service sub-layer with understand of app-flows and their
@@ -740,30 +740,30 @@ DFx = DetNet member flow x over a TE LSP
          on top of an S-Label by the node pushing an S-Label. The
          F-Labels to be pushed when sending a particular app-flow MUST
          be provisioned per app-flow via configuration, e.g., via the
-	 controller plane discussed in 
-	 <xref target="I-D.ietf-detnet-data-plane-framework"/>. 
-	 F-Labels can also provide context for an S-Label.
+         controller plane discussed in
+         <xref target="I-D.ietf-detnet-data-plane-framework"/>.
+         F-Labels can also provide context for an S-Label.
 
-	 To
+         To
          allow for the omission of F-Labels, an implementation SHOULD
          also allow an outgoing interface to be provisioned.
      </t>
      <t>
        The Packet Replication Function (PRF) function MAY be supported
-       by an implementation for outgoing DetNet flows. When replication 
-       is supported, the same app-flow data will be sent over multiple 
-       outgoing forwarding sub-layer LSPs. To support PRF an 
-       implementation MUST support the setting of different sets of 
-       F-Labels. Therefore, to allow for the omission of F-Labels, 
-       an implementation SHOULD also allow multiple outgoing interfaces 
-       to be provisioned.  PRF MUST NOT be used with app-flows configured 
+       by an implementation for outgoing DetNet flows. When replication
+       is supported, the same app-flow data will be sent over multiple
+       outgoing forwarding sub-layer LSPs. To support PRF an
+       implementation MUST support the setting of different sets of
+       F-Labels. Therefore, to allow for the omission of F-Labels,
+       an implementation SHOULD also allow multiple outgoing interfaces
+       to be provisioned.  PRF MUST NOT be used with app-flows configured
        with a d-CW sequence number field length of 0 bits.
 <!-- [Note: What if multiple receivers? We may use the PRF for serving multiple end-points.] -->
      </t>
      <t>
-       When a single set of F-Labels is provisioned for a particular 
-       outgoing app-flow, that set of F-labels MUST be pushed after 
-       the S-Label is pushed.  
+       When a single set of F-Labels is provisioned for a particular
+       outgoing app-flow, that set of F-labels MUST be pushed after
+       the S-Label is pushed.
        The outgoing packet is then forwarded as
        described below in <xref target="f-labels-all"/>. When a single
        outgoing interface is provisioned, the outgoing packet is then
@@ -837,8 +837,8 @@ DFx = DetNet member flow x over a TE LSP
          (such as queues and buffers) and provisioning or related
          parameters (such as shaping, and policing). Support can also be
          provided via an underlying network technology such IEEE802.1
-	 TSN <xref target="I-D.ietf-detnet-mpls-over-tsn"/>. 
-	 Other than in the TSN case,
+         TSN <xref target="I-D.ietf-detnet-mpls-over-tsn"/>.
+         Other than in the TSN case,
          the specific mechanisms used by a DetNet node to ensure DetNet
          service delivery requirements are met for supported DetNet
          flows is outside the scope of this document.
@@ -1027,7 +1027,7 @@ DFx = DetNet member flow x over a TE LSP
        node may participate in the packet replication and duplicate packet
        elimination.
      </t>
-     <t>       
+     <t>
        The DetNet-aware forwarder selects the egress DetNet member flow
        segment based on the flow identification.  The mapping of ingress
        DetNet member flow segment to egress DetNet member flow segment
@@ -1152,8 +1152,8 @@ DFx = DetNet member flow x over a TE LSP
 <!-- ===================================================================== -->
 
 <section anchor="mpls-flow-id-info"
-	 title="Management and Control Information Summary">
-	 <t>
+         title="Management and Control Information Summary">
+         <t>
      The following summarizes the set of information that is needed to
      identify an individual and aggregated DetNet flow for service sub-layer aware nodes:
      <list style="symbols">
@@ -1204,7 +1204,7 @@ DFx = DetNet member flow x over a TE LSP
           </t>
         </list>
       </t>
-	 <t>
+         <t>
         Much like other MPLS labels, there are a number of alternatives
         available for DetNet S-Label and F-Label advertisement to an
         upstream peer node. These include distributed signaling
@@ -1213,10 +1213,10 @@ DFx = DetNet member flow x over a TE LSP
         NETCONF/YANG, BGP, PCEP, etc., and hybrid combinations of the
         two.  The details of the controller plane solution required for
         the label distribution and the management of the label number
-        space are out of scope of this document. 
+        space are out of scope of this document.
         There are particular DetNet considerations and requirements that
         are discussed in <xref target="I-D.ietf-detnet-data-plane-framework"/>.
-      </t> 
+      </t>
 
 </section>
 <!-- ===================================================================== -->
@@ -1225,8 +1225,8 @@ DFx = DetNet member flow x over a TE LSP
 <section title="Security Considerations">
   <t>
    Security considerations for DetNet are described in detail in
-   <xref target="I-D.ietf-detnet-security"/>. General security considerations 
-   are described in <xref target="I-D.ietf-detnet-architecture"/>. This section 
+   <xref target="I-D.ietf-detnet-security"/>. General security considerations
+   are described in <xref target="I-D.ietf-detnet-architecture"/>. This section
    considers exclusively security considerations which are specific to the DetNet
    MPLS data plane.
   </t>
@@ -1236,38 +1236,38 @@ DFx = DetNet member flow x over a TE LSP
    primarily to deliver data flows with extremely low packet loss rates
    and bounded end-to-end delivery latency.
     </t>
-    <t>                
-    The primary considerations for the data plane is to maintain 
-    integrity of data and delivery of the associated DetNet service traversing 
+    <t>
+    The primary considerations for the data plane is to maintain
+    integrity of data and delivery of the associated DetNet service traversing
     the DetNet network.
     Application flows can be protected through whatever means is
     provided by the underlying technology. For example, encryption may be
     used, such as that provided by IPSec <xref target="RFC4301"/> for IP
-    flows and/or by an underlying sub-net using MACSec 
-    <xref target="IEEE802.1AE-2018"/> for IP over Ethernet (Layer-2) flows. 
+    flows and/or by an underlying sub-net using MACSec
+    <xref target="IEEE802.1AE-2018"/> for IP over Ethernet (Layer-2) flows.
     </t>
     <t>
-    From a data plane perspective this document does not add or modify any 
+    From a data plane perspective this document does not add or modify any
     header information.
     </t>
     <t>
-    At the management and control level DetNet flows are identified on a 
-    per-flow basis, which may provide controller plane 
+    At the management and control level DetNet flows are identified on a
+    per-flow basis, which may provide controller plane
     attackers with additional information about the data flows (when
     compared to controller planes that do not include per-flow identification).
     This is an inherent property of DetNet which has security
     implications that should be considered when determining if DetNet is
-    a suitable technology for any given use case.  
+    a suitable technology for any given use case.
     </t>
     <t>
-    To provide uninterrupted availability of the DetNet 
+    To provide uninterrupted availability of the DetNet
     service, provisions can be made against DOS attacks and delay
     attacks. To protect against DOS attacks, excess traffic due to
     malicious or malfunctioning devices can be prevented or mitigated,
     for example through the use of existing mechanism such as policing and shaping applied at
     the input of a DetNet domain. To prevent DetNet packets from
     being delayed by an entity external to a DetNet domain, DetNet
-    technology definition can allow for the mitigation of 
+    technology definition can allow for the mitigation of
     Man-In-The-Middle attacks, for example through use of
     authentication and authorization of devices within the DetNet domain.
   </t>
@@ -1281,10 +1281,10 @@ DFx = DetNet member flow x over a TE LSP
 
 <section anchor="acks" title="Acknowledgements">
       <t>
-		The authors wish to thank Pat Thaler, Norman Finn, Loa Anderson, David Black, 
-		Rodney Cummings, Ethan Grossman, Tal Mizrahi, David Mozes, Craig Gunther, 
-		George Swallow, Yuanlong Jiang and Carlos J. Bernardos for their
-		various contributions to this work.
+                The authors wish to thank Pat Thaler, Norman Finn, Loa Anderson, David Black,
+                Rodney Cummings, Ethan Grossman, Tal Mizrahi, David Mozes, Craig Gunther,
+                George Swallow, Yuanlong Jiang and Carlos J. Bernardos for their
+                various contributions to this work.
       </t>
 </section>
 
@@ -1327,7 +1327,7 @@ DFx = DetNet member flow x over a TE LSP
    <?rfc include="reference.RFC.6790"?>
    <?rfc include="reference.I-D.ietf-detnet-security"?>
    <?rfc include="reference.I-D.ietf-detnet-architecture"?>
- 
+
    <?rfc include="reference.I-D.ietf-spring-segment-routing-mpls'?>
    <?rfc include="reference.I-D.ietf-detnet-data-plane-framework'?>
    <?rfc include="reference.I-D.ietf-detnet-mpls-over-tsn'?>


### PR DESCRIPTION

mpls-over-ip: minor tweaks
ipOmpls: added Section 6, Management and Control Information Summary
mpls: editorial changes, refactoring of section 5 for clarity and completeness
white space cleanup (remove tabs and trailing spaces)
