### PR TITLE
TSN over MPLS: rewrite, clean up

### DIFF
--- a/tsn-vpn-over-mpls/draft-ietf-detnet-tsn-vpn-over-mpls.xml
+++ b/tsn-vpn-over-mpls/draft-ietf-detnet-tsn-vpn-over-mpls.xml
@@ -2,58 +2,10 @@
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
 <!ENTITY rfc2119 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
 <!ENTITY rfc3031 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3031.xml">
-<!ENTITY rfc3032 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3032.xml">
 <!ENTITY rfc3985 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3985.xml">
-<!ENTITY rfc4090 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4090.xml">
-<!ENTITY rfc4385 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4385.xml">
-<!ENTITY rfc4446 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4446.xml">
-<!ENTITY rfc4447 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4447.xml">
 <!ENTITY rfc4448 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4448.xml">
-<!ENTITY rfc4553 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4553.xml">
-<!ENTITY rfc4664 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4664.xml">
-<!ENTITY rfc4817 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4817.xml">
-<!ENTITY rfc4872 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4872.xml">
-<!ENTITY rfc4873 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4873.xml">
-<!ENTITY rfc5036 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5036.xml">
-<!ENTITY rfc5086 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5086.xml">
-<!ENTITY rfc5087 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5087.xml">
-<!ENTITY rfc5254 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5254.xml">
-<!ENTITY rfc5129 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5129.xml">
-<!ENTITY rfc5305 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5305.xml">
-<!ENTITY rfc5331 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5331.xml">
-<!ENTITY rfc5332 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5332.xml">
-<!ENTITY rfc5440 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5440.xml">
-<!ENTITY rfc5462 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5462.xml">
-<!ENTITY rfc5586 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5586.xml">
-<!ENTITY rfc5659 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5659.xml">
-<!ENTITY rfc5085 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5085.xml">
 <!ENTITY rfc5921 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5921.xml">
-<!ENTITY rfc5960 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5960.xml">
-<!ENTITY rfc6275 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6275.xml">
-<!ENTITY rfc6371 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6371.xml">
-<!ENTITY rfc6378 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6378.xml">
-<!ENTITY rfc6387 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6387.xml">
-<!ENTITY rfc6426 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6426.xml">
-<!ENTITY rfc6437 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6437.xml">
-<!ENTITY rfc6540 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6540.xml">
-<!ENTITY rfc6564 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6564.xml">
-<!ENTITY rfc6621 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6621.xml">
-<!ENTITY rfc6658 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6658.xml">
-<!ENTITY rfc6718 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6718.xml">
-<!ENTITY rfc6733 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6733.xml">
-<!ENTITY rfc6790 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6790.xml">
-<!ENTITY rfc7271 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7271.xml">
-<!ENTITY rfc7348 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7348.xml">
-<!ENTITY rfc7426 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7426.xml">
-<!ENTITY rfc7432 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7432.xml">
-<!ENTITY rfc7510 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7510.xml">
-<!ENTITY rfc8169 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8169.xml">
-<!ENTITY I-D.ietf-pce-pcep-extension-for-pce-controller PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-pce-pcep-extension-for-pce-controller.xml">
 <!ENTITY I-D.ietf-spring-segment-routing-mpls PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-spring-segment-routing-mpls">
-<!ENTITY I-D.ietf-detnet-problem-statement PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-problem-statement.xml">
-<!ENTITY I-D.ietf-detnet-architecture PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-architecture.xml">
-<!ENTITY I-D.ietf-detnet-flow-information-model PUBLIC "" "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-detnet-flow-information-model.xml">
-<!ENTITY I-D.ietf-mpls-residence-time SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-mpls-residence-time">
 
 ]>
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
@@ -65,7 +17,7 @@
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
 <rfc category="std"
-     docName="draft-ietf-detnet-tsn-vpn-over-mpls-00"
+     docName="draft-ietf-detnet-tsn-vpn-over-mpls-01"
          ipr="trust200902"
          submissionType="IETF">
   <front>
@@ -112,31 +64,13 @@
       </address>
     </author>
 
-    <author fullname="Jouni Korhonen" initials="J." surname="Korhonen">
-      <!--organization abbrev="Nordic">Nordic Semiconductor</organization-->
-      <address>
-        <email>jouni.nospam@gmail.com</email>
-      </address>
-    </author>
-
-  <!--author fullname="Donald Fauntleroy Duck" initials="D. F." surname="Duck">
-   <organization abbrev="Royal Bros.">Royal Bros.</organization>
-   <address>
-    <postal>
-     <street>13 Paradise Road</street>
-     <city>Duckburg</city>
-     <region>Calisota</region>
-     <country>USA</country>
-    </postal>
-   </address>
-  </author-->
   <date />
   <workgroup>DetNet</workgroup>
 
   <abstract>
    <t>
      This document specifies the Deterministic Networking data plane
-     when TSN networks interconnected over an MPLS Packet Switched Networks.
+     when TSN networks are interconnected over a DetNet MPLS Network.
    </t>
   </abstract>
   </front>
@@ -144,41 +78,29 @@
  <middle>
  <section title="Introduction" anchor="sec_intro">
   <t>
-    [Editor's note: Introduction to be made specific to TSN over DetNet scenario.
-	Do we intend to cover both TSN over DetNet IP and TSN over DetNet MPLS? Or this
-	document is limited to MPLS scenarios?].
+	The Time-Sensitive Networking Task Group (TSN TG) within IEEE 802.1 Working 
+	Group deals with deterministic services through IEEE 802 networks. 
+    Deterministic Networking (DetNet) defined by IETF is a service that can be 
+	offered by a L3 network to DetNet flows.  General background and concepts 
+	of DetNet can be found in <xref target="I-D.ietf-detnet-architecture"/>.
   </t>
-
+  <t>
+	This document specifies the use of a DetNet MPLS network to interconnect TSN 
+	nodes/network segments. DetNet MPLS data plane is defined in 
+	<xref target="I-D.ietf-detnet-mpls"/>.
+   </t>
  </section>
 
  <section title="Terminology">
-  <t>
-    [Editor's note: text to be review what is really needed here.].
-  </t>
 
   <section title="Terms Used in This Document">
   <t>
-   This document uses the terminology established in the DetNet architecture
-   <xref target="I-D.ietf-detnet-architecture"/>, and the reader is assumed
-   to be familiar with that document and its terminology.
+	This document uses the terminology and concepts established in the DetNet 
+	architecture <xref target="I-D.ietf-detnet-architecture"/> and 
+	<xref target="I-D.ietf-detnet-data-plane-framework"/>, and 
+	<xref target="I-D.ietf-detnet-mpls"/>.  The reader is assumed 
+	to be familiar with these documents and their terminology.
   </t>
-  <t>
-   The following terminology is introduced in this document:
-   <list style="hanging" hangIndent="14">
-
-    <t hangText="F-Label">A Detnet "forwarding" label that identifies the LSP used to
-    forward a DetNet flow across an MPLS PSN, e.g., a hop-by-hop
-    label used between label switching routers (LSR).</t>
-
-    <t hangText="S-Label">A DetNet "service" label that is used between DetNet
-    nodes that implement also the DetNet service sub-layer functions. An S-Label is
-    also used to identify a DetNet flow at DetNet service sub-layer.</t>
-
-    <t hangText="d-CW">
-	  A DetNet Control Word (d-CW) is used for sequencing and identifying duplicate packets of a DetNet flow at the DetNet service
-      sub-layer. </t>
-    </list>
-   </t>
   </section>
 
   <section title="Abbreviations">
@@ -195,7 +117,8 @@
     <t hangText="CW">Control Word.</t>
     <t hangText="DetNet">Deterministic Networking.</t>
     <t hangText="DF">DetNet Flow.</t>
-    <t hangText="DN-IWF">DetNet Inter-Working Function.</t>
+    <t hangText="FRER">Frame Replication and Elimination for Redundancy 
+	(TSN function).</t>
     <t hangText="L2">Layer 2.</t>
     <t hangText="L2VPN">Layer 2 Virtual Private Network.</t>
     <t hangText="L3">Layer 3.</t>
@@ -220,25 +143,37 @@
    </list>
   </t>
   </section>
- </section>  <!-- end of terminology -->
 
- <section title="Requirements Language">
+  <section title="Requirements Language">
   <t>
     The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
     "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
     "OPTIONAL" in this document are to be interpreted as described in
     BCP 14 <xref target="RFC2119"/> <xref target="RFC8174"/> when, and
     only when, they appear in all capitals, as shown here.
-  </t>
- </section>
+   </t>
+   </section>
+ </section>  <!-- end of terminology -->
 
+<!-- =========================================== -->
+<!--            TSN over DetNet MPLS             -->
+<!-- =========================================== -->
 
 <section title="IEEE 802.1 TSN Over DetNet MPLS Data Plane Scenario"
              anchor="sec_tsn_mpls_dt_dp_scen">
-      <t>
-        [Author's note: review required on his part.]
-      </t>
 
+  <t>
+   <xref target="fig_tsn_mpls_detnet"/> shows IEEE 802.1 TSN end
+   stations operating over a TSN aware DetNet service running over an
+   MPLS network.  DetNet Edge Nodes sit at the boundary of a DetNet
+   domain. They are responsible for mapping non-DetNet aware L2 traffic to
+   DetNet services.  They also support the imposition and disposition of
+   the required DetNet encapsulation.  These are functionally similar to
+   pseudowire (PW) Terminating Provider Edge (T-PE) nodes which use
+   MPLS-TE LSPs.  In this example they understand and support IEEE 802.1
+   TSN and are able to map TSN Streams into DetNet flows.  The specific of
+   this operation are discussed later in this document.
+  </t>
 
 <figure anchor="fig_tsn_mpls_detnet" align="center"
 title="A TSN over DetNet MPLS Enabled Network">
@@ -255,7 +190,7 @@ title="A TSN over DetNet MPLS Enabled Network">
 |Forwarding|  |Fwd| |Fwd|    |Forwarding|   |Fwd| |Fwd|  |Forwarding|
 +------.---+  +--.+ +-.-+    +---.----.-+   +--.+ +-.-+  +----.-----+
        :   Link  :    /  ,-----.  \   :  Link  :   /  ,-----.  \
-       +.........+    +-[  Sub  ]-+   +........+   +-[  Sub  ]-+
+       +.........+    +-[  Sub  ]-+   +........+   +-[  TSN  ]-+
                         [Network]                    [Network]
                          `-----'                      `-----'
 
@@ -264,32 +199,19 @@ title="A TSN over DetNet MPLS Enabled Network">
 </figure>
 
   <t>
-   <xref target="fig_tsn_mpls_detnet"/> shows IEEE 802.1 TSN end
-   stations operating over a TSN aware DetNet service running over an
-   MPLS network.  DetNet Edge Nodes sit at the boundary of a DetNet
-   domain. They are responsible for mapping non-DetNet aware L2 traffic to
-   DetNet services.  They also support the imposition and disposition of
-   the required DetNet encapsulation.  These are functionally similar to
-   pseudowire (PW) Terminating Provider Edge (T-PE) nodes which use
-   MPLS-TE LSPs.  In this example they understand and support IEEE 802.1
-   TSN and are able to map TSN flows into DetNet flows.  The specific of
-   this operation are discussed later in this document.
-  </t>
-  <t>
-	Native TSN flow and DetNet MPLS flow differ not only by the additional MPLS specific encapsulation, but DetNet MPLS flows have
-	on each DetNet node an associated DetNet specific data structure, what defines flow related characteristics and required
-	forwarding functions. In this example, edge Nodes provide a
-        service proxy function that "associates" the DetNet flows and native flows
-	at the edge of the DetNet domain. This ensures that the DN Flow is properly served at the Edge node (and inside the domain).
+	In this example, edge nodes provide a service proxy function that 
+	"associates" the DetNet flows and native flows (i.e., TSN Streams)
+	at the edge of the DetNet domain. This ensures that the DN Flow is 
+	properly served at the Edge node (and inside the domain).
   </t>
 
-
   <t>
-   <xref target="fig_8021_detnet"/> illustrates how DetNet can provide services for IEEE 802.1TSN
-   end systems, CE1 and CE2, over a DetNet enabled MPLS network.
-   Edge nodes, E1 and E2, insert and remove required DetNet data
-   plane encapsulation.  The 'X' in the edge nodes and relay node, R1, represent a potential DetNet compound flow
-   packet replication and elimination point.  This conceptually parallels L2VPN services, and could
+   <xref target="fig_8021_detnet"/> illustrates how DetNet can provide services 
+   for IEEE 802.1 TSN end systems, CE1 and CE2, over a DetNet enabled MPLS 
+   network.  Edge nodes, E1 and E2, insert and remove required DetNet data
+   plane encapsulation.  The 'X' in the edge nodes and relay node, R1, 
+   represent a potential DetNet compound flow  packet replication and 
+   elimination point.  This conceptually parallels L2VPN services, and could
    leverage existing related solutions as discussed below.
   </t>
 
@@ -319,287 +241,303 @@ System |    +--------+       +--------+       +--------+   |  System
 ]]>
 </artwork>
 </figure>
+
   </section>
 
+<!-- ================================================= -->
+<!--            DetNet MPLS data plane OVERVIEW        -->
+<!-- ================================================= -->
 
-<!-- ================================================================= -->
-<!-- =================== General Encap considerations ================ -->
-<!-- ================================================================= -->
+ <section title="DetNet MPLS Data Plane" anchor="sec_dt_dp">
 
-<section title="DetNet MPLS Data Plane Considerations" anchor="dn-gen-encap-solution">
-      <t>
-        [Editor's note: Needs clean up, what is relevant for TSN over DetNet scenarios.].
-      </t>
-  <t>
-    This section provides informative considerations related to
-    providing DetNet service to flows which are identified
-    based on their header information. At a high level, the
-    following are provided on a per flow basis:
-    <list style="hanging">
-      <t hangText="Eliminating contention loss and jitter reduction:">
-        <vspace blankLines="1"/>
-        Use of allocated resources (queuing, policing, shaping) to ensure
-        that the congestion-related loss and latency/jitter requirements of
-        a DetNet flow are met.
-      </t>
-      <t hangText="Explicit routes:">
-        <vspace blankLines="1"/>
-        Use of a specific path for a flow.  This limits
-        misordering and bounds latency.
-      </t>
+ <section title="Overview" anchor="sec_dt_dp_ov">
+ <t>
+	The basic approach defined in <xref target="I-D.ietf-detnet-mpls"/>
+	supports the DetNet service sub-layer based on existing pseudowire (PW) 
+	encapsulations and mechanisms, and supports the DetNet forwarding 
+	sub-layer based on existing MPLS Traffic Engineering encapsulations 
+	and mechanisms. 
+ </t>
+ <t>
+	A node operating on a DetNet flow in the Detnet service sub-layer, i.e. 
+	a node processing a DetNet packet which has the S-Label as top of stack 
+	uses the local context associated with that S-Label, for example a received 
+	F-Label, to determine what local DetNet operation(s) are applied to that 
+	packet. An S-Label may be unique when taken from the platform
+	label space <xref target="RFC3031"/>, which would enable correct DetNet flow
+	identification regardless of which input interface or LSP the packet arrives 
+	on. The service sub-layer functions (i.e., PREOF) use a DetNet control word 
+	(d-CW).
+ </t>
+ <t>
+    The DetNet MPLS data plane builds on MPLS Traffic Engineering
+    encapsulations and mechanisms to provide a forwarding sub-layer that
+    is responsible for providing resource allocation and explicit
+    routes.  The forwarding sub-layer is supported by one or more
+    forwarding labels (F-Labels).
+ </t>
+ <t>
+	DetNet edge/relay nodes are DetNet service sub-layer
+	aware, understand the particular needs of DetNet flows and
+	provide both DetNet service and forwarding sub-layer functions.
+	They add, remove and process d-CWs, S-Labels and F-labels as
+	needed.  MPLS enabled DetNet nodes can enhance the
+	reliability of delivery by enabling the replication of packets
+	where multiple copies, possibly over multiple paths, are
+	forwarded through the DetNet domain.  They can also eliminate
+	surplus previously replicated copies of DetNet packets.
+	MPLS (DetNet) nodes also include
+	DetNet forwarding sub-layer functions, support for notably
+	explicit routes, and resources allocation to eliminate (or
+	reduce) congestion loss and jitter.
+ </t>
+ <t>
+	DetNet transit nodes reside wholly within a DetNet domain, and
+	also provide DetNet forwarding sub-layer functions in accordance
+	with the performance required by a DetNet flow carried over an
+	LSP. Unlike other DetNet node types, transit nodes provide no
+	service sub-layer processing.
+ </t>
+ </section>
 
-      <t hangText="Service protection:">
-        <vspace blankLines="1"/>
-        Which in the case of this document primarily relates to
-        replication and elimination. Changing the explicit path after a
-        failure is detected in order to restore delivery of the required
-        DetNet service characteristics is also possible. Path changes,
-        even in the case of failure recovery, can lead to the out of
-        order delivery of data.
-      </t>
-      <t hangText="Load sharing:">
-        <vspace blankLines="1"/>
-        Generally, distributing packets of the same DetNet flow over
-        multiple paths is not recommended. Such load sharing,
-        e.g., via ECMP or UCMP, impacts ordering and possibly jitter.
-      </t>
-      <t hangText="Troubleshooting:"> <vspace blankLines="1"/>
-      For example, to support identification of misbehaving flows.
-      </t>
-      <t hangText="Recognize flow(s) for analytics:"><vspace blankLines="1"/>
-      For example, increase counters.
-      </t>
-      <t hangText="Correlate events with flows:"><vspace blankLines="1"/>
-      For example, unexpected loss.
-      </t>
-    </list>
-  </t>
-
-  <t>
-  The DetNet data plane also allows for the aggregation of DetNet flows, e.g., via MPLS hierarchical
-  LSPs, to improved scaling.  When DetNet flows are aggregated, transit
-  nodes provide service to the aggregate and not on a per-DetNet flow
-  basis.  In this case, nodes performing aggregation will ensure that
-  per-flow service requirements are achieved.
+ <section anchor="tom-encap"
+               title="TSN over DetNet MPLS Encapsulation">
+ <t>
+	The basic encapsulation approach is to treat a TSN Stream as an app-flow 
+	from the DetNet MPLS perspective. The corresponding example shown in 
+	<xref target="fig_tsn_mpls_ex"/>.
  </t>
 
- <section title="End-System Specific Considerations">
-  <t>
-   Data-flows requiring DetNet service are generated and terminated on
-   end-systems. Encapsulation depends on application and its
-   preferences. In a DetNet MPLS domain the DN functions use the d-CWs,
-   S-Labels and F-Labels to provide DetNet services. However, an
-   application may exchange further flow related parameters (e.g.,
-   time-stamp), which are not provided by DN functions.
-  </t>
+  <figure title="Example TSN over MPLS Encapsulation Formats"
+              anchor="fig_tsn_mpls_ex">
+        <artwork align="center"><![CDATA[
 
-  <t>
-    Specifics related to non-MPLS DetNet end station behavior are out
-    side the scope of this document.  For example, details on support
-    for DetNet IP data flows can be found in <xref
-    target="I-D.ietf-detnet-dp-sol-ip"/>. This document is also useful
-    for end stations that map IP flows to DetNet flows.
-  </t>
-  <t>
-   As a general rule, DetNet MPLS domains are capable of forwarding any
-   DetNet MPLS flows and the DetNet domain does not mandate the
-   end-system or edge system encapsulation format. Unless there is a
-   proxy of some form present, end-systems peer with similar end-systems
-   using the same application encapsulation format.  For example, as
-   shown in <xref target="fig_es_connect"/>, IP applications peer with
-   IP applications and Ethernet L2VPN applications peer with Ethernet
-   L2VPN applications.
-  </t>
+           /->     +------+  +------+  +------+   Appli    ^ ^
+           |       |  X   |  |  X   |  |  X   |<- cation   : :
+App-Flow <-+       +------+  +------+  +------+            : :(1)
+ for MPLS  |       |TSN-L2|  |TSN-L2|  |TSN-L2|            : v
+           \-> +---+======+--+======+--+======+-----+      :
+                   | d-CW |  | d-CW |  | d-CW |            :
+DetNet-MPLS        +------+  +------+  +------+            :(2)
+                   |Labels|  |Labels|  |Labels|            v
+               +---+======+--+======+--+======+-----+
+Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
+                   +------+  +------+  +------+
+                                       |  IP  |
+                                       +------+
+                                       |  L2  |
+                                       +------+
+    (1) TSN Stream 
+    (2) DetNet MPLS Flow
+    ]]>
+        </artwork>
+  </figure>
 
-  <figure title="End-Systems and The DetNet MPLS Domain" anchor="fig_es_connect">
-  <artwork align="center"><![CDATA[
-+-----+
-|  X  |                               +-----+
-+-----+                               |  X  |
-| Eth |               ________        +-----+
-+-----+     _____    /        \       | Eth |
-       \   /     \__/          \___   +-----+
-        \ /                        \ /
-         0======== tunnel-1 ========0_
-         |                             \
-          \                             |
-          0========= tunnel-2 =========0
-         / \                        __/ \
-  +-----+   \__ DetNet MPLS domain /     \
-  |  X  |      \         __       /       +-----+
-  +-----+       \_______/  \_____/        |  X  |
-  |  IP |                                 +-----+
-  +-----+                                 |  IP |
-                                          +-----+
-  ]]>
-    </artwork></figure>
-
- </section>
+ <t>
+	In the figure, "Application" indicates the application payload carried by 
+	the TSN network. "MPLS App-Flow" indicates that the TSN Stream is the 
+	payload from the perspective of the DetNet MPLS data plane defined in 
+	<xref target="I-D.ietf-detnet-mpls"/>. A single DetNet MPLS flow 
+	can aggregate multiple TSN Streams.
+ </t>
  </section>
 
-<!-- ================================================================= -->
+ </section>  <!-- end of DetNet MPLS data plane overview -->
 
-<section title="MPLS-Based DetNet Data Plane Solution" anchor="dn-dt-solution">
+<!-- ================================================= -->
+<!--            TSN over DetNet MPLS procedures        -->
+<!-- ================================================= -->
 
-      <t>
-        [Editor's note: Needs clean up. Text should focus on Edge node related topics.].
-      </t>
+ <section title="TSN over MPLS Data Plane Procedures" anchor="tom_proc">
 
-
- <section title="DetNet Over MPLS Encapsulation Components" anchor="dn-MPLS-en-comps">
   <t>
-   To carry DetNet over MPLS the following is required:
-
-  <list style="numbers">
-   <t>A method of identifying the MPLS payload type.</t>
-   <t>A method of identifying the DetNet flow group to the processing element.</t>
-   <t>A method of distinguishing DetNet OAM packets from DetNet data packets.</t>
-   <t>A method of carrying the DetNet sequence number.</t>
-   <t>A suitable LSP to deliver the packet to the egress PE.</t>
-   <t>A method of carrying queuing and forwarding indication.</t>
-  </list>
+	Description of Edge Nodes procedures and functions for TSN over DetNet MPLS
+	scenario follows the concept of <xref target="RFC3985"/> and covers the 
+	Edge Nodes components shown on <xref target="fig_tsn_mpls_detnet"/>. In 
+	this section the following procedures of DetNet Edge Nodes are described:
+	<list style="symbols">
+		<t>
+			TSN related (<xref target="tom_tsn_proc"/>)
+		</t><t>
+			DetNet Service Proxy (<xref target="tom_svc_prx_proc"/>)
+		</t><t>
+			DetNet service and forwarding sub-layer (<xref target="tom_dn_sub_proc"/>)
+		</t>
+	</list>
   </t>
-  <t>
-   In this design an MPLS service label (the S-Label), similar to a pseudowire
-   (PW) label <xref target="RFC3985"/>,
-   is used to identify both the DetNet flow identity and the payload MPLS payload type satisfying
-   (1) and (2) in the list above.  OAM traffic discrimination happens through the use of the
-   Associated Channel method described in <xref target="RFC4385"/>.  The DetNet sequence number is carried in the DetNet
-   Control word which carries the Data/OAM discriminator.
-   To simplify implementation and to maximize interoperability two sequence number sizes are
-   supported: a 16 bit sequence number and a 28 bit sequence number.
-   The 16 bit sequence number is needed to support some types of legacy clients. The 28 bit sequence
-   number is used in situations where it is necessary ensure that in high speed networks the
-   sequence number space does not wrap whilst packets are in flight.
-  </t>
-  <t>
-   The LSP used to forward the DetNet
-   packet may be of any type (MPLS-LDP, MPLS-TE, MPLS-TP <xref
-   target="RFC5921"/>, or
-   MPLS-SR <xref target="I-D.ietf-spring-segment-routing-mpls"/>).  The LSP (F-Label) label and/or the S-Label may
-   be used to indicate the queue processing as well as the forwarding parameters.
-   Note that the possible use of Penultimate
-   Hop Popping (PHP) means that the only label in a received label stack may be the S-Label.
-  </t>
- </section>
 
-  <section title="TSN over MPLS Data Plane Encapsulation" anchor="pwSolution">
-
-
-   <section title="Edge Node Processing" anchor="sec_t_pe">
+  <section title="Edge Node TSN Procedures" anchor="tom_tsn_proc">
     <t>
-     An edge node is resposable for matching ingress packets to the service they require and
-     encapsulating them accordingly.An edge node may participate in the packet replication and
-     duplication elimination.
+        The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1 
+		Working Group have defined (and are defining) a number of amendments 
+		to <xref target="IEEE8021Q">IEEE 802.1Q</xref> that provide zero 
+		congestion loss and bounded latency in bridged networks.
+        <xref target="IEEE8021CB">IEEE 802.1CB</xref> defines packet 
+		replication and elimination functions for a TSN network.
+  	</t>
+  	<t>
+		TSN specific functions are executed on the data received by 
+		the PE from the CE before presentation to the DetNet PW for 
+		transmission across the DetNet domain, or on the data received from 
+		a DetNet PW by a PE before it is output on the Attachment Circuit (AC). 
+  	</t>
+  	<t>
+		TSN specific function(s) of Edge Nodes (T-PE) are belonging to the 
+		native service processing (NSP) <xref target="RFC3985"/> 
+		block. This is similar to other functionalities being defined by standard 
+		bodies other than the IETF (for example in case of Ethernet: stripping, 
+		overwriting or adding VLAN tags, etc.). Depending on the TSN role of 
+		the Edge Node in the end-to-end TSN service selected TSN functions 
+		must be supported. 
     </t>
     <t>
-     The DetNet-aware forwarder selects the egress DetNet member flow segment based on the flow identification.
-     The mapping of ingress DetNet member flow segment to egress DetNet member flow segment may be
-     statically or dynamically configured. Additionally the DetNet-aware
-     forwarder does duplicate frame elimination based on the flow identification and
-     the sequence number combination. The packet replication is
-     also done within the DetNet-aware forwarder. During elimination and the
-     replication process the sequence number of the DetNet member flow MUST
-     be preserved and copied to the egress DetNet member flow.
+		Implementations of this document SHALL use management and
+		control information to ensure TSN specific functions of the Edge Node
+		according to the expectations of the connected TSN network. 
+    </t>
+  </section>
+
+  <section title="Edge Node DetNet Service Proxy Procedures" anchor="tom_svc_prx_proc">
+  	<t>
+		The Service Proxy function maps between App-flows and DetNet flows. 
+		It MUST support the TSN Stream identification functions and the 
+		related managed objects as defined in 
+		<xref target="IEEE8021CB">IEEE 802.1CB</xref> and 
+		<xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref> to recognize 
+		the App-flow related packets. 
     </t>
     <t>
-     The internal design of a relay node is out of scope of this document. However
-     the reader's attention is drawn to the need to make any PREOF state
-     available to the packet processor(s) dealing with packets to which the
-     PREOF functions must be applied, and to maintain that state is such as
-     way that it is available to the packet processor operation on the next
-     packet in the DetNet flow (which may be a duplicate, a late packet, or
-     the next packet in sequence.
+		Implementations of this document SHALL use management and
+		control information to map a TSN Stream to a DetNet flow. 
+		N:1 mapping (aggregating TSN Streams in a single
+		DetNet flow) SHALL be supported. The management or control
+		function that provisions flow mapping SHALL ensure that
+		adequate resources are allocated and configured to provide
+		proper service requirements of the mapped flows.
+	</t>
+	<t>
+		Due to the (intentional) similarities of the DetNet PREOF and TSN FRER 
+		functions service protection function interworking is possible between 
+		the TSN and the DetNet domains. Such service protection interworking 
+		scenarios MAY require to copy sequence number fields from TSN (L2) to 
+		PW (MPLS) encapsulation. However, such interworking is out-of-scope in 
+		this document and left for further study.
+	</t>
+  </section>
+
+  <section title="Edge Node DetNet Service and Forwarding Sub-Layer Procedures" anchor="tom_dn_sub_proc">
+  	<t>
+		In the design of <xref target="I-D.ietf-detnet-mpls"/> an MPLS service 
+		label (the S-Label), similar to a pseudowire (PW) label 
+		<xref target="RFC3985"/>, is used to identify both the DetNet flow 
+		identity and the payload MPLS payload type.  The DetNet sequence 
+		number is carried in the DetNet Control word (d-CW) which carries the 
+		Data/OAM discriminator as well. In 
+		<xref target="I-D.ietf-detnet-mpls"/> two sequence number sizes 
+		are supported: a 16 bit sequence number and a 28 bit sequence number.
     </t>
     <t>
-      [Editor's note: I think the rest of this section belongs in a new "802.1 TSN
-      (island Interconnect) over DetNet MPLS" section.]
-    </t>
+		PREOF functions and the provided service recovery is available
+		only within the DetNet domain as the DetNet flow-ID and the DetNet
+		sequence number are not valid outside the DetNet network.  MPLS
+		(DetNet) Edge node terminates all related information elements 
+		encoded in the MPLS labels.
+	</t>
+	<t>
+		The LSP used to forward the DetNet packet may be of any type (MPLS-LDP, 
+		MPLS-TE, MPLS-TP <xref target="RFC5921"/>, or MPLS-SR 
+		<xref target="I-D.ietf-spring-segment-routing-mpls"/>).  The LSP 
+		(F-Label) label and/or the S-Label may be used to indicate the queue 
+		processing as well as the forwarding parameters.
+	</t>
     <t>
-     This may be done in the DetNet layer, or where the native service
-     processing (NSP) <xref target="RFC3985"/> is IEEE 802.1CB <xref target="IEEE8021CB"/> capable,
-     the packet replication and duplicate elimination MAY entirely be done in the NSP, bypassing
-     the DetNet flow encapsulation and logic entirely. This enables operating over unmodified
-     implementations and deployments. The NSP approach works only between edge nodes and cannot
-     make use of relay nodes.
-    </t>
-    <t>
-     The NSP approach is useful end to end tunnel and for for "island interconnect"
-     scenarios. However, when there is a need to do PREOF in a middle of the network,
-     such plain edge to edge operation is not sufficient.
-    </t>
-    <t>
-      The extended forwarder MAY copy the sequencing information from the native DetNet packet into
-      the DetNet sequence number field and vice versa. If there is no existing sequencing
-      information available in the native packet or the forwarder chose not to copy it from the
-      native packet, then the extended forwarder MUST maintain a sequence number counter for each
-      DetNet flow (indexed by the DetNet flow identification).
-    </t>
-   </section>
+		For further details see <xref target="I-D.ietf-detnet-mpls"/>.
+	</t>
+  </section>
+
+ </section>  <!-- End of Procedures Section -->
 
 
- <section title="Layer 2 Addressing and QoS Considerations">
-  <t> [Editor's NOTE: review and simplify this section if possible.]
-  </t>
-    <t>
-        The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1 Working Group have
-        defined (and are defining) a number of amendments to <xref target="IEEE8021Q">IEEE 802.1Q</xref>
-        that provide zero congestion loss and bounded latency in bridged networks.
-        <xref target="IEEE8021CB">IEEE 802.1CB</xref> defines packet replication and elimination
-        functions that should prove both compatible with and useful to, DetNet networks.
-    </t><t>
-        As is the case for DetNet, a Layer 2 network node such as a bridge may need to
-        identify the specific DetNet flow to which a packet belongs in order to provide the
-        TSN/DetNet QoS for that packet.  It also will likely need a CoS marking, such as the
-        priority field of an IEEE Std 802.1Q VLAN tag, to give the packet proper service.
-    </t><t>
-        Although the flow identification methods described in <xref target="IEEE8021CB">IEEE 802.1CB</xref>
-        are flexible, and in fact, include IP 5-tuple identification methods, the baseline
-        TSN standards assume that every Ethernet frame belonging to a TSN stream
-        (i.e. DetNet flow) carries a multicast destination MAC address that is unique to that
-        flow within the bridged network over which it is carried.  Furthermore,
-        <xref target="IEEE8021CB">IEEE 802.1CB</xref> describes three methods by which a packet
-        sequence number can be encoded in an Ethernet frame.
-    </t><t>
-        Ensuring that the proper Ethernet VLAN tag priority and destination MAC address
-        are used on a DetNet/TSN packet may require further clarification of the customary
-        L2/L3 transformations carried out by routers and edge label switches.  Edge nodes
-        may also have to move sequence number fields among Layer 2, PW, and IP encapsulations.
-    </t>
- </section>
+<!-- ========================================================== -->
+<!--          Management and Control Plane Considerations       -->
+<!-- ========================================================== -->
 
+ <section title="Controller Plane (Management and Control) Considerations" anchor="cp_considerations">
 
+   <t>
+	[Editor's note: This section covers management/control plane related
+	implications of creation, mapping, removal of DetNet flow IDs, their
+	related parameters and, when needed, the configuration of PREOF.]
+   </t>
+   <t>
+	TSN Stream(s) to DetNet flow mapping related information are
+	required only for the service proxy function of MPLS (DetNet) Edge nodes. 
+	From the Data Plane perspective there is no practical difference
+	based on the origin of flow mapping related information	(management plane 
+	or control plane).
+   </t>
+   <t>
+	MPLS DetNet Edge nodes are member of both the DetNet domain and the 
+	connected TSN network. From the TSN network perspective the MPLS (DetNet) 
+	Edge node has a "TSN relay node" role, so TSN specific management and
+	control plane functionalities must be implemented.  There are many 
+	similarities in the management plane techniques used in DetNet and TSN, 
+	but that is not the case for the control plane protocols. For example, 
+	RSVP-TE and MSRP behaves differently. Therefore management and control
+	plane design is an important aspect of scenarios, where	mapping between 
+	DetNet and TSN is required.
+   </t>
+   <t>
+	In order to use a DetNet network to interconnect TSN segments,
+	TSN specific information must be converted to DetNet domain
+	specific ones. TSN Stream ID(s) and stream(s) related
+	parameters/requirements must be converted to a DetNet flow-ID and 
+	flow related parameters/requirements. Note that, as the DetNet network 
+	is just a portion of the end2end TSN path (i.e., single hop from 
+	Ethernet perspective), some parameters (e.g., delay) may differ 
+	significantly. Other parameters (like bandwidth) also may have to 
+	be tuned due to the MPLS encapsulation used within the DetNet network.
+   </t>
+   <t>
+	In some case it may be challenging to determine some egress node
+	related information. For example, it may be not trivial to
+	locate the egress point/interface of a TSN Streams with a 
+	multicast destination MAC address. Such scenarios may
+	require interaction between control and management plane
+	functions and between DetNet and TSN domains.
+   </t>
+   <t>
+	Mapping between DetNet flow identifiers and TSN Stream
+	identifiers, if not provided explicitly, can be done by the service
+	proxy function of an MPLS (DetNet) Edge node locally based on information
+	provided for configuration of the TSN Stream identification functions 
+	(e.g., Mask-and-Match Stream identification).
+   </t>
+   <t>
+	Triggering the setup/modification of a DetNet flow in the
+	DetNet network is an example where management and/or
+	control plane interactions are required between the DetNet
+	and the TSN network. 
+   </t>
+   <t>
+	Configuration of TSN specific functions (e.g., FRER)
+	inside the TSN network is a TSN domain specific decision 
+	and may not be visible in the DetNet domain. Service protection
+	interworking scenarios are left for further study.
+   </t>
 
-
- </section>
-
-
-</section>
-
-
-<!-- ===================================================================== -->
-
-<section title="Controller Plane (Management and Control)
-                Considerations" anchor="cp_considerations">
-
-      <t>
-        [Editor's note: requires considerations related to TSN over DetNet.].
-      </t>
-
-</section>
-
-
+ </section> <!-- End of Management and Control Plane COnsiderations -->
 
 <section title="Security Considerations">
   <t>
-   The security considerations of DetNet in general are discussed in
-   <xref target="I-D.ietf-detnet-architecture"/>
-   and <xref target="I-D.sdt-detnet-security"/>. Other security
-   considerations will be added in a future version of
-   this draft.
+        The security considerations of DetNet in general are discussed in
+        <xref target="I-D.ietf-detnet-architecture"/>
+        and <xref target="I-D.ietf-detnet-security"/>. DetNet MPLS data plane 
+		specific considerations are summarized in 
+		<xref target="I-D.ietf-detnet-mpls"/>. Encryption may provided within
+		the TSN network using MACSec <xref target="IEEE802.1AE-2018"/>.
   </t>
 </section>
-
 
 <section anchor="iana" title="IANA Considerations">
   <t>
@@ -609,7 +547,9 @@ System |    +--------+       +--------+       +--------+   |  System
 
 <section anchor="acks" title="Acknowledgements">
    <t>
-   Thanks for Norman Finn and Lou Berger for their comments and contributions.
+		The authors wish to thank Norman Finn, Lou Berger, Craig Gunther,
+		Christophe Mangin and Jouni Korhonen for their various contributions 
+		to this work.
    </t>
 </section>
 </middle>
@@ -617,70 +557,19 @@ System |    +--------+       +--------+       +--------+   |  System
 <back>
   <references title="Normative References">
    &rfc2119;
-   <?rfc include="reference.RFC.2211"?>
-   <?rfc include="reference.RFC.2212"?>
    <?rfc include="reference.RFC.3031"?>
-   <?rfc include="reference.RFC.3032"?>
-   <?rfc include="reference.RFC.3209"?>
-   <?rfc include="reference.RFC.3270"?>
-   <?rfc include="reference.RFC.3443"?>
-   <?rfc include="reference.RFC.3473"?>
-   <?rfc include="reference.RFC.4206"?>
-   <?rfc include="reference.RFC.5129"?>
-   <?rfc include="reference.RFC.5085"?>
-   <?rfc include="reference.RFC.5462"?>
-   &rfc4385;
-   &rfc7510;
    <?rfc include="reference.RFC.8174"?>
   </references>
   <references title="Informative References">
-   <?rfc include="reference.RFC.2205"?>
-   <?rfc include="reference.RFC.2474"?>
-   <?rfc include="reference.RFC.3272"?>
    &rfc3985;
    &rfc4448;
-   &rfc4872;
-   &rfc4873;
-   <?rfc include="reference.RFC.4875"?>
-   <?rfc include="reference.RFC.5440"?>
-   <?rfc include="reference.RFC.5586"?>
-   <?rfc include="reference.RFC.5654"?>
-   <?rfc include="reference.RFC.5921"?>
-   <?rfc include="reference.RFC.6073"?>
-   <?rfc include="reference.RFC.6003"?>
-   <?rfc include="reference.RFC.6006"?>
-  &rfc6387;
-    <?rfc include="reference.RFC.6790"?>
-   <?rfc include="reference.RFC.7950"?>
-   <?rfc include="reference.RFC.7551"?>
-   <?rfc include="reference.RFC.8040"?>
-   &I-D.ietf-pce-pcep-extension-for-pce-controller;
-&I-D.ietf-detnet-architecture;
-&I-D.ietf-detnet-flow-information-model;
+   &rfc5921;
    &I-D.ietf-spring-segment-routing-mpls;
-   <reference anchor='I-D.ietf-detnet-dp-sol-ip'>
-     <front>
-       <title>DetNet IP Data Plane Encapsulation
-       </title>
-       <author>
-         <organization>Korhonen, J., Varga, B.</organization>
-       </author>
-       <date year='2018' />
-     </front>
-   </reference>
-   &rfc8169;
-
-   <reference anchor='I-D.sdt-detnet-security'>
-    <front>
-     <title>Deterministic Networking (DetNet) Security Considerations,
-		draft-sdt-detnet-security, work in progress
-     </title>
-     <author>
-      <organization>Mizrahi, T., Grossman, E., Hacker, A., Das, S.</organization>
-     </author>
-     <date year='2017' />
-    </front>
-   </reference>
+      <?rfc include="reference.I-D.ietf-detnet-architecture"?>
+      <?rfc include="reference.I-D.ietf-detnet-data-plane-framework"?>
+      <?rfc include="reference.I-D.ietf-detnet-ip"?>
+      <?rfc include="reference.I-D.ietf-detnet-mpls"?>
+      <?rfc include="reference.I-D.ietf-detnet-security"?>
 
    <reference anchor='IEEE1588'>
      <front>
@@ -693,6 +582,17 @@ System |    +--------+       +--------+       +--------+   |  System
        <date year='2008' />
      </front>
    </reference>
+
+    <reference anchor="IEEE802.1AE-2018"
+      target="https://ieeexplore.ieee.org/document/8585421">
+      <front>
+        <title>IEEE Std 802.1AE-2018 MAC Security (MACsec)</title>
+        <author>
+          <organization>IEEE Standards Association</organization>
+        </author>
+        <date year="2018" />
+      </front>
+    </reference>
 
    <reference anchor="IEEE8021Q"
      target="http://standards.ieee.org/about/get/">
@@ -719,6 +619,19 @@ System |    +--------+       +--------+       +--------+   |  System
     <format type="PDF" target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf"/>
    </reference>
 
+      <reference anchor="IEEEP8021CBdb"
+                 target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf">
+        <front>
+          <title>Extended Stream identification functions</title>
+          <author initials="C. M." surname="Mangin" fullname="Christophe Mangin">
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date month="August" year="2019"/>
+        </front>
+        <seriesInfo name="IEEE P802.1CBdb /D0.2" value="P802.1CBdb"/>
+        <format type="PDF" target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf"/>
+      </reference>
+
    <reference anchor="G.8275.1"
               target="https://www.itu.int/rec/T-REC-G.8275.1/en">
      <front>
@@ -744,12 +657,6 @@ System |    +--------+       +--------+       +--------+   |  System
    </reference>
 
   </references>
- <section title="Example of TSN over DetNet Data Plane Operation" anchor="sec_comb">
-  <t>
-   [Editor's note: Add a simplified example of DetNet data plane and how labels etc
-   work in the case of TSN over DetNet MPLS and utilizing e.g., PREOF.]
-  </t>
- </section>
 
  </back>
 </rfc>


### PR DESCRIPTION
Major clean up and simplification as data plane drafts can be referred for MPLS related details. 
TSN over DetNet MPLS follows the concept of RFC3985. Description focus on Edge Nodes 
procedures and functions.  Text covers the Edge Nodes components: 
(1) TSN functions (in NSP block); 
(2) DetNet Service Proxy; and 
(3) DetNet sub-layers.