### PR TITLE
ip-over-mpls: IESG-review (fixing Martin Duke's comment)

### DIFF
--- a/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
+++ b/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
@@ -163,17 +163,15 @@
             <t hangText="DF">DetNet Flow.</t>
             <t hangText="DN">DetNet.</t>
             <t hangText="L2">Layer-2.</t>
-            <t hangText="L3">Layer-3.</t>
             <t hangText="LSP">Label-switched path.</t>
             <t hangText="MPLS">Multiprotocol Label Switching.</t>
-            <t hangText="PE">Provider Edge.</t>
             <t hangText="PEF">Packet Elimination Function.</t>
             <t hangText="PRF">Packet Replication Function.</t>
             <t hangText="PREOF">Packet Replication, Elimination and Ordering Functions.</t>
             <t hangText="POF">Packet Ordering Function.</t>
-            <t hangText="PSN">Packet Switched Network.</t>
             <t hangText="PW">Pseudowire.</t>
 		    <t hangText="S-Label">DetNet "service" label.</t>
+		    <t hangText="S-PE">Switching Provider Edge.</t>
 		    <t hangText="T-PE">Terminating Provider Edge.</t>
             <t hangText="TE">Traffic Engineering.</t>
             <t hangText="TSN">Time-Sensitive Networking, TSN is a Task Group of the IEEE			
@@ -533,8 +531,8 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
       <t>
         It is the responsibility of the DetNet controller plane to
         properly provision both flow identification information and
-        the flow specific resources needed to provided the traffic
-        treatment needed to meet each flow's service requirements.
+        the flow-specific resources needed to provide the traffic
+        treatment to meet each flow's service requirements.
         This applies for aggregated and individual flows.
       </t>
     </section>

--- a/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
+++ b/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
@@ -462,6 +462,11 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
           Note that such configuration MAY include support from PREOF on the
           incoming DetNet MPLS flow.
         </t>
+		<t>
+          Note: using Layer-4 (L4) transport protocols e.g., for multipath are 
+		  out of scope of this document both for a single flow and aggregate 
+		  flows.
+        </t>
       </section>
       <section anchor="iom-svc"
                title="DetNet IP over DetNet MPLS Traffic Treatment Procedures">

--- a/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
+++ b/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
@@ -641,10 +641,10 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
       <?rfc include="reference.I-D.ietf-detnet-data-plane-framework"?>
           <?rfc include="reference.I-D.ietf-detnet-mpls'?>
       <?rfc include="reference.I-D.ietf-detnet-ip'?>
+      <?rfc include="reference.I-D.ietf-detnet-security"?>
         </references>
 
     <references title="Informative references">
-      <?rfc include="reference.I-D.ietf-detnet-security"?>
       <?rfc include="reference.RFC.4301"?>
       <reference anchor="IEEE802.1AE-2018"
       target="https://ieeexplore.ieee.org/document/8585421">

--- a/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
+++ b/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
@@ -640,13 +640,13 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
       <?rfc include="reference.RFC.2119"?>
       <?rfc include="reference.RFC.8174"?>
       <?rfc include="reference.RFC.8655"?>
+      <?rfc include="reference.I-D.ietf-detnet-data-plane-framework"?>
           <?rfc include="reference.I-D.ietf-detnet-mpls'?>
       <?rfc include="reference.I-D.ietf-detnet-ip'?>
         </references>
 
     <references title="Informative references">
       <?rfc include="reference.I-D.ietf-detnet-security"?>
-      <?rfc include="reference.I-D.ietf-detnet-data-plane-framework"?>
       <?rfc include="reference.RFC.4301"?>
       <reference anchor="IEEE802.1AE-2018"
       target="https://ieeexplore.ieee.org/document/8585421">


### PR DESCRIPTION
Note added to 5.1, that L4 multipath is out-of-scope. 
Please, check note and its placement that it is appropriate.
https://mailarchive.ietf.org/arch/msg/detnet/GLBlvKQWog8V9iqoHaEcBGW5ECs/
https://mailarchive.ietf.org/arch/msg/detnet/MNJKPDUR57nHMEkH9j2idywThRs/