### PR TITLE
ip-over-mpls: proposed fixings after telechat

### DIFF
--- a/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
+++ b/ip-over-mpls/draft-ietf-detnet-ip-over-mpls.xml
@@ -426,6 +426,15 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
      </section>
 
      <section anchor="iom-proc" title="IP over DetNet MPLS Procedures">
+      <t>
+        Main differences of mapping to DetNet MPLS (compared to plain MPLS) are
+		that (1) there is a mandatory flow identification to make the forwarding 
+		decision (i.e., forwarding is not based on FEC), (2) the d-CW (DetNet 
+		Control Word) is mandatory for the MPLS encapsulation and (3) during 
+		forwarding over the DetNet MPLS network DetNet flow specific treatment 
+		is needed.
+      </t>
+ 
       <section anchor="iom-ids"
                title="DetNet IP over DetNet MPLS Flow Identification
                       and Aggregation Procedures">
@@ -458,8 +467,9 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
           target="I-D.ietf-detnet-ip"/> Section 5.1.
         </t>
         <t>
-          An implementation MUST support the provisioning for handling any
-          received DetNet MPLS data plane as DetNet IP flows via configuration.
+          An implementation MUST support the provisioning for handling any 
+		  packet flows received via DetNet MPLS data plane as DetNet IP flows 
+		  via configuration.
           Note that such configuration MAY include support from PREOF on the
           incoming DetNet MPLS flow.
         </t>


### PR DESCRIPTION
Changes:
1, Section “5.  IP over DetNet MPLS Procedures” Add new text before section 5.1.
2, Fix a nit in penultimate paragraph of “5.1.  DetNet IP over DetNet MPLS Flow Identification 
and Aggregation Procedures”