### PR TITLE
TSN drafts: fixings based on Shepherd's comments

### DIFF
--- a/ip-over-tsn/IDs/draft-ietf-detnet-ip-over-tsn-04.html
+++ b/ip-over-tsn/IDs/draft-ietf-detnet-ip-over-tsn-04.html
@@ -1,0 +1,815 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+
+  <title>DetNet Data Plane: IP over IEEE 802.1 Time Sensitive Networking (TSN)</title>
+
+  <style type="text/css" title="Xml2Rfc (sans serif)">
+  /*<![CDATA[*/
+	  a {
+	  text-decoration: none;
+	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
+	  a.smpl {
+	  color: black;
+	  }
+	  a:hover {
+	  text-decoration: underline;
+	  }
+	  a:active {
+	  text-decoration: underline;
+	  }
+	  address {
+	  margin-top: 1em;
+	  margin-left: 2em;
+	  font-style: normal;
+	  }
+	  body {
+	  color: black;
+	  font-family: verdana, helvetica, arial, sans-serif;
+	  font-size: 10pt;
+	  max-width: 55em;
+	  
+	  }
+	  cite {
+	  font-style: normal;
+	  }
+	  dd {
+	  margin-right: 2em;
+	  }
+	  dl {
+	  margin-left: 2em;
+	  }
+	
+	  ul.empty {
+	  list-style-type: none;
+	  }
+	  ul.empty li {
+	  margin-top: .5em;
+	  }
+	  dl p {
+	  margin-left: 0em;
+	  }
+	  dt {
+	  margin-top: .5em;
+	  }
+	  h1 {
+	  font-size: 14pt;
+	  line-height: 21pt;
+	  page-break-after: avoid;
+	  }
+	  h1.np {
+	  page-break-before: always;
+	  }
+	  h1 a {
+	  color: #333333;
+	  }
+	  h2 {
+	  font-size: 12pt;
+	  line-height: 15pt;
+	  page-break-after: avoid;
+	  }
+	  h3, h4, h5, h6 {
+	  font-size: 10pt;
+	  page-break-after: avoid;
+	  }
+	  h2 a, h3 a, h4 a, h5 a, h6 a {
+	  color: black;
+	  }
+	  img {
+	  margin-left: 3em;
+	  }
+	  li {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol p {
+	  margin-left: 0em;
+	  }
+	  p {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  pre {
+	  margin-left: 3em;
+	  background-color: lightyellow;
+	  padding: .25em;
+	  }
+	  pre.text2 {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f0f0f0;
+	  width: 69em;
+	  }
+	  pre.inline {
+	  background-color: white;
+	  padding: 0em;
+	  }
+	  pre.text {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  width: 69em;
+	  }
+	  pre.drawing {
+	  border-style: solid;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  padding: 2em;
+	  }
+	  table {
+	  margin-left: 2em;
+	  }
+	  table.tt {
+	  vertical-align: top;
+	  }
+	  table.full {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.headers {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.tt td {
+	  vertical-align: top;
+	  }
+	  table.full td {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.tt th {
+	  vertical-align: top;
+	  }
+	  table.full th {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.headers th {
+	  border-style: none none inset none;
+	  border-width: 1px;
+	  }
+	  table.left {
+	  margin-right: auto;
+	  }
+	  table.right {
+	  margin-left: auto;
+	  }
+	  table.center {
+	  margin-left: auto;
+	  margin-right: auto;
+	  }
+	  caption {
+	  caption-side: bottom;
+	  font-weight: bold;
+	  font-size: 9pt;
+	  margin-top: .5em;
+	  }
+	
+	  table.header {
+	  border-spacing: 1px;
+	  width: 95%;
+	  font-size: 10pt;
+	  color: white;
+	  }
+	  td.top {
+	  vertical-align: top;
+	  }
+	  td.topnowrap {
+	  vertical-align: top;
+	  white-space: nowrap; 
+	  }
+	  table.header td {
+	  background-color: gray;
+	  width: 50%;
+	  }
+	  table.header a {
+	  color: white;
+	  }
+	  td.reference {
+	  vertical-align: top;
+	  white-space: nowrap;
+	  padding-right: 1em;
+	  }
+	  thead {
+	  display:table-header-group;
+	  }
+	  ul.toc, ul.toc ul {
+	  list-style: none;
+	  margin-left: 1.5em;
+	  margin-right: 0em;
+	  padding-left: 0em;
+	  }
+	  ul.toc li {
+	  line-height: 150%;
+	  font-weight: bold;
+	  font-size: 10pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  ul.toc li li {
+	  line-height: normal;
+	  font-weight: normal;
+	  font-size: 9pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  li.excluded {
+	  font-size: 0pt;
+	  }
+	  ul p {
+	  margin-left: 0em;
+	  }
+	
+	  .comment {
+	  background-color: yellow;
+	  }
+	  .center {
+	  text-align: center;
+	  }
+	  .error {
+	  color: red;
+	  font-style: italic;
+	  font-weight: bold;
+	  }
+	  .figure {
+	  font-weight: bold;
+	  text-align: center;
+	  font-size: 9pt;
+	  }
+	  .filename {
+	  color: #333333;
+	  font-weight: bold;
+	  font-size: 12pt;
+	  line-height: 21pt;
+	  text-align: center;
+	  }
+	  .fn {
+	  font-weight: bold;
+	  }
+	  .hidden {
+	  display: none;
+	  }
+	  .left {
+	  text-align: left;
+	  }
+	  .right {
+	  text-align: right;
+	  }
+	  .title {
+	  color: #990000;
+	  font-size: 18pt;
+	  line-height: 18pt;
+	  font-weight: bold;
+	  text-align: center;
+	  margin-top: 36pt;
+	  }
+	  .vcardline {
+	  display: block;
+	  }
+	  .warning {
+	  font-size: 14pt;
+	  background-color: yellow;
+	  }
+	
+	
+	  @media print {
+	  .noprint {
+		display: none;
+	  }
+	
+	  a {
+		color: black;
+		text-decoration: none;
+	  }
+	
+	  table.header {
+		width: 90%;
+	  }
+	
+	  td.header {
+		width: 50%;
+		color: black;
+		background-color: white;
+		vertical-align: top;
+		font-size: 12pt;
+	  }
+	
+	  ul.toc a::after {
+		content: leader('.') target-counter(attr(href), page);
+	  }
+	
+	  ul.ind li li a {
+		content: target-counter(attr(href), page);
+	  }
+	
+	  .print2col {
+		column-count: 2;
+		-moz-column-count: 2;
+		column-fill: auto;
+	  }
+	  }
+	
+	  @page {
+	  @top-left {
+		   content: "Internet-Draft"; 
+	  } 
+	  @top-right {
+		   content: "December 2010"; 
+	  } 
+	  @top-center {
+		   content: "Abbreviated Title";
+	  } 
+	  @bottom-left {
+		   content: "Doe"; 
+	  } 
+	  @bottom-center {
+		   content: "Expires June 2011"; 
+	  } 
+	  @bottom-right {
+		   content: "[Page " counter(page) "]"; 
+	  } 
+	  }
+	
+	  @page:first { 
+		@top-left {
+		  content: normal;
+		}
+		@top-right {
+		  content: normal;
+		}
+		@top-center {
+		  content: normal;
+		}
+	  }
+  /*]]>*/
+  </style>
+
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.2" rel="Chapter" title="2 Terminology">
+<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Terms Used In This Document">
+<link href="#rfc.section.2.2" rel="Chapter" title="2.2 Abbreviations">
+<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Requirements Language">
+<link href="#rfc.section.3" rel="Chapter" title="3 DetNet IP Data Plane Overview">
+<link href="#rfc.section.4" rel="Chapter" title="4 DetNet IP Flows over an IEEE 802.1   TSN sub-network">
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 Functions for DetNet Flow to TSN Stream Mapping">
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 TSN requirements of IP DetNet nodes">
+<link href="#rfc.section.4.3" rel="Chapter" title="4.3 Service protection within the TSN sub-network">
+<link href="#rfc.section.4.4" rel="Chapter" title="4.4 Aggregation during DetNet flow to TSN Stream mapping">
+<link href="#rfc.section.5" rel="Chapter" title="5 Management and Control Implications">
+<link href="#rfc.section.6" rel="Chapter" title="6 Security Considerations">
+<link href="#rfc.section.7" rel="Chapter" title="7 IANA Considerations">
+<link href="#rfc.section.8" rel="Chapter" title="8 Acknowledgements">
+<link href="#rfc.references" rel="Chapter" title="9 References">
+<link href="#rfc.references.1" rel="Chapter" title="9.1 Normative references">
+<link href="#rfc.references.2" rel="Chapter" title="9.2 Informative references">
+<link href="#rfc.authors" rel="Chapter">
+
+
+  <meta name="generator" content="xml2rfc version 2.22.3 - https://tools.ietf.org/tools/xml2rfc" />
+  <link rel="schema.dct" href="http://purl.org/dc/terms/" />
+
+  <meta name="dct.creator" content="Varga, B., Ed., Farkas, J., Malis, A., and S. Bryant" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-detnet-ip-over-tsn-04" />
+  <meta name="dct.issued" scheme="ISO8601" content="2020-03" />
+  <meta name="dct.abstract" content="This document specifies the Deterministic Networking IP data plane when operating over a TSN sub-network. This document does not define new procedures or processes.  Whenever this document makes requirements statements or recommendations, these are taken from normative text in the referenced RFCs.  " />
+  <meta name="description" content="This document specifies the Deterministic Networking IP data plane when operating over a TSN sub-network. This document does not define new procedures or processes.  Whenever this document makes requirements statements or recommendations, these are taken from normative text in the referenced RFCs.  " />
+
+</head>
+
+<body>
+
+  <table class="header">
+    <tbody>
+    
+    	<tr>
+<td class="left">DetNet</td>
+<td class="right">B. Varga, Ed.</td>
+</tr>
+<tr>
+<td class="left">Internet-Draft</td>
+<td class="right">J. Farkas</td>
+</tr>
+<tr>
+<td class="left">Intended status: Informational</td>
+<td class="right">Ericsson</td>
+</tr>
+<tr>
+<td class="left">Expires: May 7, 2021</td>
+<td class="right">A. Malis</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">Malis Consulting</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">S. Bryant</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">Futurewei Technologies</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">November 3, 2020</td>
+</tr>
+
+    	
+    </tbody>
+  </table>
+
+  <p class="title">DetNet Data Plane: IP over IEEE 802.1 Time Sensitive Networking (TSN)<br />
+  <span class="filename">draft-ietf-detnet-ip-over-tsn-04</span></p>
+  
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+<p>This document specifies the Deterministic Networking IP data plane when operating over a TSN sub-network. This document does not define new procedures or processes.  Whenever this document makes requirements statements or recommendations, these are taken from normative text in the referenced RFCs.  </p>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
+<p>This Internet-Draft will expire on May 7, 2021.</p>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
+<p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+
+  
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
+  <ul class="toc">
+
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<li>2.   <a href="#rfc.section.2">Terminology</a>
+</li>
+<ul><li>2.1.   <a href="#rfc.section.2.1">Terms Used In This Document</a>
+</li>
+<li>2.2.   <a href="#rfc.section.2.2">Abbreviations</a>
+</li>
+<li>2.3.   <a href="#rfc.section.2.3">Requirements Language</a>
+</li>
+</ul><li>3.   <a href="#rfc.section.3">DetNet IP Data Plane Overview</a>
+</li>
+<li>4.   <a href="#rfc.section.4">DetNet IP Flows over an IEEE 802.1   TSN sub-network</a>
+</li>
+<ul><li>4.1.   <a href="#rfc.section.4.1">Functions for DetNet Flow to TSN Stream Mapping</a>
+</li>
+<li>4.2.   <a href="#rfc.section.4.2">TSN requirements of IP DetNet nodes</a>
+</li>
+<li>4.3.   <a href="#rfc.section.4.3">Service protection within the TSN sub-network</a>
+</li>
+<li>4.4.   <a href="#rfc.section.4.4">Aggregation during DetNet flow to TSN Stream mapping</a>
+</li>
+</ul><li>5.   <a href="#rfc.section.5">Management and Control Implications</a>
+</li>
+<li>6.   <a href="#rfc.section.6">Security Considerations</a>
+</li>
+<li>7.   <a href="#rfc.section.7">IANA Considerations</a>
+</li>
+<li>8.   <a href="#rfc.section.8">Acknowledgements</a>
+</li>
+<li>9.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>9.1.   <a href="#rfc.references.1">Normative references</a>
+</li>
+<li>9.2.   <a href="#rfc.references.2">Informative references</a>
+</li>
+</ul><li><a href="#rfc.authors">Authors' Addresses</a>
+</li>
+
+
+  </ul>
+
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> <a href="#sec_intro" id="sec_intro">Introduction</a>
+</h1>
+<p id="rfc.section.1.p.1">Deterministic Networking (DetNet) is a service that can be offered by a network to DetNet flows.  DetNet provides these flows extremely low packet loss rates and assured maximum end-to-end delivery latency.  General background and concepts of DetNet can be found in the DetNet Architecture <a href="#RFC8655" class="xref">[RFC8655]</a>.  </p>
+<p><a href="#I-D.ietf-detnet-ip" class="xref">[I-D.ietf-detnet-ip]</a> specifies the DetNet data plane operation for IP hosts and routers that provide DetNet service to IP encapsulated data.  This document focuses on the scenario where DetNet IP nodes are interconnected by a TSN sub-network.  </p>
+<p id="rfc.section.1.p.3">The DetNet Architecture decomposes the DetNet related data plane functions into two sub-layers: a service sub-layer and a forwarding sub-layer.  The service sub-layer is used to provide DetNet service protection and reordering. The forwarding sub-layer is used to provides congestion protection (low loss, assured latency, and limited reordering). As described in <a href="#I-D.ietf-detnet-ip" class="xref">[I-D.ietf-detnet-ip]</a> no DetNet specific headers are added to support DetNet IP flows, only the forwarding sub-layer functions are supported inside the DetNet domain. Service protection can be provided on a per sub-network basis as shown here for the IEEE802.1 TSN sub-network scenario.  </p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> Terminology</h1>
+<h1 id="rfc.section.2.1">
+<a href="#rfc.section.2.1">2.1.</a> Terms Used In This Document</h1>
+<p id="rfc.section.2.1.p.1">This document uses the terminology and concepts established in the DetNet architecture <a href="#RFC8655" class="xref">[RFC8655]</a>, and the reader is assumed to be familiar with that document and its terminology.  </p>
+<h1 id="rfc.section.2.2">
+<a href="#rfc.section.2.2">2.2.</a> Abbreviations</h1>
+<p id="rfc.section.2.2.p.1">The following abbreviations used in this document: </p>
+
+<dl>
+<dt>DetNet</dt>
+<dd style="margin-left: 14">Deterministic Networking.</dd>
+<dt>DF</dt>
+<dd style="margin-left: 14">DetNet Flow.</dd>
+<dt>FRER</dt>
+<dd style="margin-left: 14">Frame Replication and Elimination for Redundancy (TSN function).</dd>
+<dt>L2</dt>
+<dd style="margin-left: 14">Layer-2.</dd>
+<dt>L3</dt>
+<dd style="margin-left: 14">Layer-3.</dd>
+<dt>PREOF</dt>
+<dd style="margin-left: 14">Packet Replication, Ordering and Elimination Function.</dd>
+<dt>TSN</dt>
+<dd style="margin-left: 14">Time-Sensitive Networking, TSN is a Task Group of the IEEE 802.1 Working Group.</dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.section.2.3">
+<a href="#rfc.section.2.3">2.3.</a> Requirements Language</h1>
+<p id="rfc.section.2.3.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <a href="#RFC2119" class="xref">[RFC2119]</a> <a href="#RFC8174" class="xref">[RFC8174]</a> when, and only when, they appear in all capitals, as shown here.  </p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> <a href="#sec_dt_dp" id="sec_dt_dp">DetNet IP Data Plane Overview</a>
+</h1>
+<p><a href="#I-D.ietf-detnet-ip" class="xref">[I-D.ietf-detnet-ip]</a> describes how IP is used by DetNet nodes, i.e., hosts and routers, to identify DetNet flows and provide a DetNet service. From a data plane perspective, an end-to-end IP model is followed.  DetNet uses "6-tuple" based flow identification, where "6-tuple" refers to information carried in IP and higher layer protocol headers.  </p>
+<p id="rfc.section.3.p.2">DetNet flow aggregation may be enabled via the use of wildcards, masks, prefixes and ranges. IP tunnels may also be used to support flow aggregation. In these cases, it is expected that DetNet aware intermediate nodes will provide DetNet service assurance on the aggregate through resource allocation and congestion control mechanisms.  </p>
+<p id="rfc.section.3.p.3">Congestion protection, latency control and the resource allocation (queuing, policing, shaping) are supported using the underlying link / sub-net specific mechanisms.  Service protections (packet replication and packet elimination functions) are not provided at the IP DetNet layer end-to-end due the lack of a unified end-to-end sequencing information that would be available for intermediate nodes.  However, such service protection can be provided on a per underlying L2 link and sub-network basis.  </p>
+<p id="rfc.section.3.p.4">DetNet routers ensure that DetNet service requirements are met per hop by allocating local resources, both receive and transmit, and by mapping the service requirements of each flow to appropriate sub-network mechanisms.  Such mappings are sub-network technology specific.  DetNet nodes interconnected by a TSN sub-network are the primary focus of this document.  The mapping of DetNet IP flows to TSN streams and TSN protection mechanisms are covered in <a href="#mapping-tsn" class="xref">Section 4</a>.  </p>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> <a href="#mapping-tsn" id="mapping-tsn">DetNet IP Flows over an IEEE 802.1   TSN sub-network</a>
+</h1>
+<p id="rfc.section.4.p.1">This section covers how DetNet IP flows operate over an IEEE 802.1 TSN sub-network.  <a href="#fig_ip_detnet_to_tsn" class="xref">Figure 1</a> illustrates such a scenario, where two IP (DetNet) nodes are interconnected by a TSN sub-network.  Dotted lines around the Service components of the IP (DetNet) Nodes indicate that they are DetNet service aware but do not perform any DetNet service sub-layer function.  Node-1 is single homed and Node-2 is dual-homed to the TSN sub-network.  </p>
+<div id="rfc.figure.1"></div>
+<div id="fig_ip_detnet_to_tsn"></div>
+<pre>
+    IP (DetNet)                   IP (DetNet)
+      Node-1                        Node-2
+
+   ............                  ............
+&lt;--: Service  :-- DetNet flow ---: Service  :--&gt;
+   +----------+                  +----------+
+   |Forwarding|                  |Forwarding|
+   +--------.-+    &lt;-TSN Str-&gt;   +-.-----.--+
+             \      ,-------.     /     /
+              +----[ TSN-Sub ]---+     /
+                   [ Network ]--------+
+                    `-------'
+&lt;----------------- DetNet IP -----------------&gt;
+</pre>
+<p class="figure">Figure 1: DetNet (DN) Enabled IP Network over a TSN sub-network</p>
+<p id="rfc.section.4.p.2">The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1 Working Group have defined (and are defining) a number of amendments to <a href="#IEEE8021Q" class="xref">IEEE 802.1Q</a> that provide zero congestion loss and bounded latency in bridged networks. Furthermore, <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> defines frame replication and elimination functions for reliability that should prove both compatible with and useful to DetNet networks.  All these functions have to identify flows that require TSN treatment.  </p>
+<p id="rfc.section.4.p.3">TSN capabilities of the TSN sub-network are made available for IP (DetNet) flows via the protocol interworking function desribed in Annex C.5 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a>. For example, applied on the TSN edge port it can convert an ingress unicast IP (DetNet) flow to use a specific Layer-2 multicast destination MAC address and a VLAN, in order to direct the packet through a specific path inside the bridged network.  A similar interworking function pair at the other end of the TSN sub-network would restore the packet to its original Layer-2 destination MAC address and VLAN.  </p>
+<p id="rfc.section.4.p.4">Placement of TSN functions depends on the TSN capabilities of nodes. IP (DetNet) Nodes may or may not support TSN functions. For a given TSN Stream (i.e., a mapped DetNet flow) an IP (DetNet) node is treated as a Talker or a Listener inside the TSN sub-network.  </p>
+<h1 id="rfc.section.4.1">
+<a href="#rfc.section.4.1">4.1.</a> Functions for DetNet Flow to TSN Stream Mapping</h1>
+<p id="rfc.section.4.1.p.1">Mapping of a DetNet IP flow to a TSN Stream is provided via the combination of a passive and an active stream identification function that operate at the frame level (Layer-2). The passive stream identification function is used to catch the 6-tuple of a DetNet IP flow and the active stream identification function is used to modify the Ethernet header according to the ID of the mapped TSN Stream.  </p>
+<p id="rfc.section.4.1.p.2">Clause 6.7 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> defines an IP Stream identification function that can be used as a passive function for IP DetNet flows using UDP or TCP. Clause 6.8 of <a href="#IEEEP8021CBdb" class="xref">IEEE P802.1CBdb</a> defines a Mask-and-Match Stream identification function that can be used as a passive function for any IP DetNet flows.  </p>
+<p id="rfc.section.4.1.p.3">Clause 6.6 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> defines an Active Destination MAC and VLAN Stream identification function, what can replace some Ethernet header fields namely (1) the destination MAC-address, (2) the VLAN-ID and (3) priority parameters with alternate values. Replacement is provided for the frame passed down the stack from the upper layers or up the stack from the lower layers.  </p>
+<p id="rfc.section.4.1.p.4">Active Destination MAC and VLAN Stream identification can be used within a Talker to set flow identity or a Listener to recover the original addressing information. It can be used also in a TSN bridge that is providing translation as a proxy service for an End System.  </p>
+<h1 id="rfc.section.4.2">
+<a href="#rfc.section.4.2">4.2.</a> TSN requirements of IP DetNet nodes</h1>
+<p id="rfc.section.4.2.p.1">This section covers required behavior of a TSN-aware DetNet node using a TSN sub-network. The implementation of TSN packet processing functions must be compliant with the relevant IEEE 802.1 standards.  </p>
+<p id="rfc.section.4.2.p.2">From the TSN sub-network perspective DetNet IP nodes are treated as Talker or Listener, that may be (1) TSN-unaware or (2) TSN-aware.  </p>
+<p id="rfc.section.4.2.p.3">In cases of TSN-unaware IP DetNet nodes the TSN relay nodes within the TSN sub-network must modify the Ethernet encapsulation of the DetNet IP flow (e.g., MAC translation, VLAN-ID setting, Sequence number addition, etc.) to allow proper TSN specific handling inside the sub-network.  There are no requirements defined for TSN-unaware IP DetNet nodes in this document.  </p>
+<p id="rfc.section.4.2.p.4">IP (DetNet) nodes being TSN-aware can be treated as a combination of a TSN-unaware Talker/Listener and a TSN-Relay, as shown in <a href="#fig_ip_with_tsn" class="xref">Figure 2</a>.  In such cases the IP (DetNet) node must provide the TSN sub-network specific Ethernet encapsulation over the link(s) towards the sub-network.  </p>
+<div id="rfc.figure.2"></div>
+<div id="fig_ip_with_tsn"></div>
+<pre>
+               IP (DetNet)
+                  Node
+   &lt;----------------------------------&gt;
+
+   ............
+&lt;--: Service  :-- DetNet flow ------------------
+   +----------+
+   |Forwarding|
+   +----------+    +---------------+
+   |    L2    |    | L2 Relay with |&lt;--- TSN ---
+   |          |    | TSN function  |    Stream
+   +-----.----+    +--.------.---.-+
+          \__________/        \   \______
+                               \_________
+    TSN-unaware
+     Talker /          TSN-Bridge
+     Listener             Relay
+                                       &lt;----- TSN Sub-network -----
+   &lt;------- TSN-aware Tlk/Lstn -------&gt;
+</pre>
+<p class="figure">Figure 2: IP (DetNet) node with TSN functions</p>
+<p id="rfc.section.4.2.p.5">A TSN-aware IP (DetNet) node impementations must support the Stream Identification TSN component for recognizing flows.  </p>
+<p id="rfc.section.4.2.p.6">A Stream identification component must be able to instantiate the following functions (1) Active Destination MAC and VLAN Stream identification function, (2) IP Stream identification function, (3) Mask-and-Match Stream identification function and (4) the related managed objects in Clause 9 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> and <a href="#IEEEP8021CBdb" class="xref">IEEE P802.1CBdb</a>.  </p>
+<p id="rfc.section.4.2.p.7">A TSN-aware IP (DetNet) node implementations must support the Sequencing function and the Sequence encode/decode function as defined in Clause 7.4 and 7.6 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> if FRER is used inside the TSN sub-network.  </p>
+<p id="rfc.section.4.2.p.8">The Sequence encode/decode function must support the Redundancy tag (R-TAG) format as per Clause 7.8 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a>.  </p>
+<p id="rfc.section.4.2.p.9">A TSN-aware IP (DetNet) node implementations must support the Stream splitting function and the Individual recovery function as defined in Clause 7.7 and 7.5 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> when the node is a replication or elimination point for FRER.  </p>
+<h1 id="rfc.section.4.3">
+<a href="#rfc.section.4.3">4.3.</a> Service protection within the TSN sub-network</h1>
+<p id="rfc.section.4.3.p.1">TSN Streams supporting DetNet flows may use Frame Replication and Elimination for Redundancy (FRER) as defined in Clause 8. of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> based on the loss service requirements of the TSN Stream, which is derived from the DetNet service requirements of the DetNet mapped flow.  The specific operation of FRER is not modified by the use of DetNet and follows <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a>.  </p>
+<p id="rfc.section.4.3.p.2">FRER function and the provided service recovery is available only within the TSN sub-network as the TSN Stream-ID and the TSN sequence number are not valid outside the sub-network.  An IP (DetNet) node represents a L3 border and as such it terminates all related information elements encoded in the L2 frames.  </p>
+<h1 id="rfc.section.4.4">
+<a href="#rfc.section.4.4">4.4.</a> Aggregation during DetNet flow to TSN Stream mapping</h1>
+<p id="rfc.section.4.4.p.1">Implementations of this document shall use management and control information to map a DetNet flow to a TSN Stream. N:1 mapping (aggregating DetNet flows in a single TSN Stream) shall be supported. The management or control function that provisions flow mapping shall ensure that adequate resources are allocated and configured to provide proper service requirements of the mapped flows.  </p>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> Management and Control Implications</h1>
+<p id="rfc.section.5.p.1">DetNet flow and TSN Stream mapping related information are required only for TSN-aware IP (DetNet) nodes. From the Data Plane perspective there is no practical difference based on the origin of flow mapping related information (management plane or control plane).  </p>
+<p id="rfc.section.5.p.2">The following summarizes the set of information that is needed to configure DetNet IP over TSN: </p>
+
+<ul>
+<li>DetNet IP related configuration information according to the DetNet role of the DetNet IP node, as per <a href="#I-D.ietf-detnet-ip" class="xref">[I-D.ietf-detnet-ip]</a>. </li>
+<li>TSN related configuration information according to the TSN role of the DetNet IP node, as per <a href="#IEEE8021Q" class="xref">[IEEE8021Q]</a>, <a href="#IEEE8021CB" class="xref">[IEEE8021CB]</a> and <a href="#IEEEP8021CBdb" class="xref">[IEEEP8021CBdb]</a>. </li>
+<li>Mapping between DetNet IP flow(s) (as flow identification defined in <a href="#I-D.ietf-detnet-ip" class="xref">[I-D.ietf-detnet-ip]</a>, it is summarized in Section 5.1 of that document, and includes all wildcards, port ranges and the ability to ignore specific IP fields) and TSN Stream(s) (as stream identification information defined in <a href="#IEEE8021CB" class="xref">[IEEE8021CB]</a> and <a href="#IEEEP8021CBdb" class="xref">[IEEEP8021CBdb]</a>).  Note, that managed objects for TSN Stream identification can be found in <a href="#IEEEP8021CBcv" class="xref">[IEEEP8021CBcv]</a>.  </li>
+</ul>
+
+<p> This information must be provisioned per DetNet flow.  </p>
+<p id="rfc.section.5.p.3">Mappings between DetNet and TSN management and control planes are out of scope of the document. Some of the challanges are highligthed below.  </p>
+<p id="rfc.section.5.p.4">TSN-aware IP DetNet nodes are member of both the DetNet domain and the TSN sub-network.  Within the TSN sub-network the TSN-aware IP (DetNet) node has a TSN-aware Talker/Listener role, so TSN specific management and control plane functionalities must be implemented.  There are many similarities in the management plane techniques used in DetNet and TSN, but that is not the case for the control plane protocols. For example, RSVP-TE and MSRP behaves differently. Therefore management and control plane design is an important aspect of scenarios, where mapping between DetNet and TSN is required.  </p>
+<p id="rfc.section.5.p.5">In order to use a TSN sub-network between DetNet nodes, DetNet specific information must be converted to TSN sub-network specific ones. DetNet flow ID and flow related parameters/requirements must be converted to a TSN Stream ID and stream related parameters/requirements. Note that, as the TSN sub-network is just a portion of the end-to-end DetNet path (i.e., single hop from IP perspective), some parameters (e.g., delay) may differ significantly. Other parameters (like bandwidth) also may have to be tuned due to the L2 encapsulation used within the TSN sub-network.  </p>
+<p id="rfc.section.5.p.6">In some case it may be challenging to determine some TSN Stream related information. For example, on a TSN-aware IP (DetNet) node that acts as a Talker, it is quite obvious which DetNet node is the Listener of the mapped TSN stream (i.e., the IP Next-Hop). However it may be not trivial to locate the point/interface where that Listener is connected to the TSN sub-network. Such attributes may require interaction between control and management plane functions and between DetNet and TSN domains.  </p>
+<p id="rfc.section.5.p.7">Mapping between DetNet flow identifiers and TSN Stream identifiers, if not provided explicitly, can be done by a TSN-aware IP (DetNet) node locally based on information provided for configuration of the TSN Stream identification functions (IP Stream identification, Mask-and-match Stream identification and active Stream identification function).  </p>
+<p id="rfc.section.5.p.8">Triggering the setup/modification of a TSN Stream in the TSN sub-network is an example where management and/or control plane interactions are required between the DetNet and TSN sub-network. TSN-unaware IP (DetNet) nodes make such a triggering even more complicated as they are fully unaware of the sub-network and run independently.  </p>
+<p id="rfc.section.5.p.9">Configuration of TSN specific functions (e.g., FRER) inside the TSN sub-network is a TSN domain specific decision and may not be visible in the DetNet domain.  </p>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> Security Considerations</h1>
+<p id="rfc.section.6.p.1">Security considerations for DetNet are described in detail in <a href="#I-D.ietf-detnet-security" class="xref">[I-D.ietf-detnet-security]</a>. General security considerations are described in <a href="#RFC8655" class="xref">[RFC8655]</a>.  DetNet IP data plane specific considerations are summarized in <a href="#I-D.ietf-detnet-ip" class="xref">[I-D.ietf-detnet-ip]</a>.  This section considers exclusively security considerations which are specific to the DetNet IP over TSN sub-network scenario.  </p>
+<p id="rfc.section.6.p.2">The sub-network between DetNet nodes needs to be subject to appropriate confidentiality. Additionally, knowledge of what DetNet/TSN services are provided by a sub-network may supply information that can be used in a variety of security attacks. The ability to modify information exchanges between connected DetNet nodes may result in bogus operations. Therefore, it is important that the interface between DetNet nodes and TSN sub-network are subject to authorization, authentication, and encryption.  </p>
+<p id="rfc.section.6.p.3">The TSN sub-network operates at Layer-2 so various security mechanisms defined by IEEE can be used to secure the connection between the DetNet nodes (e.g., encryption may be provided using MACSec <a href="#IEEE802.1AE-2018" class="xref">[IEEE802.1AE-2018]</a>).  </p>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#iana" id="iana">IANA Considerations</a>
+</h1>
+<p id="rfc.section.7.p.1">None.  </p>
+<h1 id="rfc.section.8">
+<a href="#rfc.section.8">8.</a> <a href="#acks" id="acks">Acknowledgements</a>
+</h1>
+<p id="rfc.section.8.p.1">The authors wish to thank Norman Finn, Lou Berger, Craig Gunther, Christophe Mangin and Jouni Korhonen for their various contributions to this work.  </p>
+<h1 id="rfc.references">
+<a href="#rfc.references">9.</a> References</h1>
+<h1 id="rfc.references.1">
+<a href="#rfc.references.1">9.1.</a> Normative references</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="I-D.ietf-detnet-ip">[I-D.ietf-detnet-ip]</b></td>
+<td class="top">
+<a>Varga, B.</a>, <a>Farkas, J.</a>, <a>Berger, L.</a>, <a>Fedyk, D.</a> and <a>S. Bryant</a>, "<a href="https://tools.ietf.org/html/draft-ietf-detnet-ip-07">DetNet Data Plane: IP</a>", Internet-Draft draft-ietf-detnet-ip-07, July 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8174">[RFC8174]</b></td>
+<td class="top">
+<a>Leiba, B.</a>, "<a href="https://tools.ietf.org/html/rfc8174">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a>", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.references.2">
+<a href="#rfc.references.2">9.2.</a> Informative references</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="I-D.ietf-detnet-flow-information-model">[I-D.ietf-detnet-flow-information-model]</b></td>
+<td class="top">
+<a>Varga, B.</a>, <a>Farkas, J.</a>, <a>Cummings, R.</a>, <a>Jiang, Y.</a> and <a>D. Fedyk</a>, "<a href="https://tools.ietf.org/html/draft-ietf-detnet-flow-information-model-11">DetNet Flow Information Model</a>", Internet-Draft draft-ietf-detnet-flow-information-model-11, October 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-detnet-security">[I-D.ietf-detnet-security]</b></td>
+<td class="top">
+<a>Grossman, E.</a>, <a>Mizrahi, T.</a> and <a>A. Hacker</a>, "<a href="https://tools.ietf.org/html/draft-ietf-detnet-security-12">Deterministic Networking (DetNet) Security Considerations</a>", Internet-Draft draft-ietf-detnet-security-12, October 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEE802.1AE-2018">[IEEE802.1AE-2018]</b></td>
+<td class="top">
+<a>IEEE Standards Association</a>, "<a href="https://ieeexplore.ieee.org/document/8585421">IEEE Std 802.1AE-2018 MAC Security (MACsec)</a>", 2018.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEE8021CB">[IEEE8021CB]</b></td>
+<td class="top">
+<a>IEEE 802.1</a>, "<a href="http://standards.ieee.org/about/get/">Standard for Local and metropolitan area networks - Frame Replication and Elimination for Reliability (IEEE Std 802.1CB-2017)</a>", 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEE8021Q">[IEEE8021Q]</b></td>
+<td class="top">
+<a>IEEE 802.1</a>, "<a href="http://standards.ieee.org/about/get/">Standard for Local and metropolitan area networks--Bridges and Bridged Networks (IEEE Std 802.1Q-2018)</a>", 2018.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEEP8021CBcv">[IEEEP8021CBcv]</b></td>
+<td class="top">
+<a title="IEEE 802.1">Kehrer, S.</a>, "<a href="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf">FRER YANG Data Model and Management Information Base Module</a>", IEEE P802.1CBcv /D0.4 P802.1CBcv, August 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEEP8021CBdb">[IEEEP8021CBdb]</b></td>
+<td class="top">
+<a title="IEEE 802.1">Mangin, C.</a>, "<a href="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf">Extended Stream identification functions</a>", IEEE P802.1CBdb /D1.0 P802.1CBdb, September 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8655">[RFC8655]</b></td>
+<td class="top">
+<a>Finn, N.</a>, <a>Thubert, P.</a>, <a>Varga, B.</a> and <a>J. Farkas</a>, "<a href="https://tools.ietf.org/html/rfc8655">Deterministic Networking Architecture</a>", RFC 8655, DOI 10.17487/RFC8655, October 2019.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
+<div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Bal&#225;zs Varga</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Varga</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Ericsson</span>
+	<span class="adr">
+	  <span class="vcardline">Magyar Tudosok krt. 11.</span>
+
+	  <span class="vcardline">
+		<span class="locality">Budapest</span>,  
+		<span class="region"></span>
+		<span class="code">1117</span>
+	  </span>
+	  <span class="country-name vcardline">Hungary</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:balazs.a.varga@ericsson.com">balazs.a.varga@ericsson.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">J&#225;nos Farkas</span> 
+	  <span class="n hidden">
+		<span class="family-name">Farkas</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Ericsson</span>
+	<span class="adr">
+	  <span class="vcardline">Magyar Tudosok krt. 11.</span>
+
+	  <span class="vcardline">
+		<span class="locality">Budapest</span>,  
+		<span class="region"></span>
+		<span class="code">1117</span>
+	  </span>
+	  <span class="country-name vcardline">Hungary</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:janos.farkas@ericsson.com">janos.farkas@ericsson.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Andrew G. Malis</span> 
+	  <span class="n hidden">
+		<span class="family-name">Malis</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Malis Consulting</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:agmalis@gmail.com">agmalis@gmail.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Stewart Bryant</span> 
+	  <span class="n hidden">
+		<span class="family-name">Bryant</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Futurewei Technologies</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:stewart.bryant@gmail.com">stewart.bryant@gmail.com</a></span>
+
+  </address>
+</div>
+
+</body>
+</html>

--- a/ip-over-tsn/IDs/draft-ietf-detnet-ip-over-tsn-04.html
+++ b/ip-over-tsn/IDs/draft-ietf-detnet-ip-over-tsn-04.html
@@ -424,7 +424,7 @@
 <td class="right">Ericsson</td>
 </tr>
 <tr>
-<td class="left">Expires: May 7, 2021</td>
+<td class="left">Expires: May 6, 2021</td>
 <td class="right">A. Malis</td>
 </tr>
 <tr>
@@ -441,7 +441,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">November 3, 2020</td>
+<td class="right">November 2, 2020</td>
 </tr>
 
     	
@@ -457,7 +457,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on May 7, 2021.</p>
+<p>This Internet-Draft will expire on May 6, 2021.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>

--- a/ip-over-tsn/IDs/draft-ietf-detnet-ip-over-tsn-04.txt
+++ b/ip-over-tsn/IDs/draft-ietf-detnet-ip-over-tsn-04.txt
@@ -1,0 +1,672 @@
+
+
+
+
+DetNet                                                     B. Varga, Ed.
+Internet-Draft                                                 J. Farkas
+Intended status: Informational                                  Ericsson
+Expires: May 6, 2021                                            A. Malis
+                                                        Malis Consulting
+                                                               S. Bryant
+                                                  Futurewei Technologies
+                                                        November 2, 2020
+
+
+ DetNet Data Plane: IP over IEEE 802.1 Time Sensitive Networking (TSN)
+                    draft-ietf-detnet-ip-over-tsn-04
+
+Abstract
+
+   This document specifies the Deterministic Networking IP data plane
+   when operating over a TSN sub-network.  This document does not define
+   new procedures or processes.  Whenever this document makes
+   requirements statements or recommendations, these are taken from
+   normative text in the referenced RFCs.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on May 6, 2021.
+
+Copyright Notice
+
+   Copyright (c) 2020 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+
+
+
+Varga, et al.              Expires May 6, 2021                  [Page 1]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   3
+     2.1.  Terms Used In This Document . . . . . . . . . . . . . . .   3
+     2.2.  Abbreviations . . . . . . . . . . . . . . . . . . . . . .   3
+     2.3.  Requirements Language . . . . . . . . . . . . . . . . . .   3
+   3.  DetNet IP Data Plane Overview . . . . . . . . . . . . . . . .   3
+   4.  DetNet IP Flows over an IEEE 802.1   TSN sub-network  . . . .   4
+     4.1.  Functions for DetNet Flow to TSN Stream Mapping . . . . .   5
+     4.2.  TSN requirements of IP DetNet nodes . . . . . . . . . . .   6
+     4.3.  Service protection within the TSN sub-network . . . . . .   8
+     4.4.  Aggregation during DetNet flow to TSN Stream mapping  . .   8
+   5.  Management and Control Implications . . . . . . . . . . . . .   8
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  10
+   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     9.1.  Normative references  . . . . . . . . . . . . . . . . . .  10
+     9.2.  Informative references  . . . . . . . . . . . . . . . . .  11
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  12
+
+1.  Introduction
+
+   Deterministic Networking (DetNet) is a service that can be offered by
+   a network to DetNet flows.  DetNet provides these flows extremely low
+   packet loss rates and assured maximum end-to-end delivery latency.
+   General background and concepts of DetNet can be found in the DetNet
+   Architecture [RFC8655].
+
+   [I-D.ietf-detnet-ip] specifies the DetNet data plane operation for IP
+   hosts and routers that provide DetNet service to IP encapsulated
+   data.  This document focuses on the scenario where DetNet IP nodes
+   are interconnected by a TSN sub-network.
+
+   The DetNet Architecture decomposes the DetNet related data plane
+   functions into two sub-layers: a service sub-layer and a forwarding
+   sub-layer.  The service sub-layer is used to provide DetNet service
+   protection and reordering.  The forwarding sub-layer is used to
+   provides congestion protection (low loss, assured latency, and
+   limited reordering).  As described in [I-D.ietf-detnet-ip] no DetNet
+   specific headers are added to support DetNet IP flows, only the
+   forwarding sub-layer functions are supported inside the DetNet
+
+
+
+Varga, et al.              Expires May 6, 2021                  [Page 2]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+   domain.  Service protection can be provided on a per sub-network
+   basis as shown here for the IEEE802.1 TSN sub-network scenario.
+
+2.  Terminology
+
+2.1.  Terms Used In This Document
+
+   This document uses the terminology and concepts established in the
+   DetNet architecture [RFC8655], and the reader is assumed to be
+   familiar with that document and its terminology.
+
+2.2.  Abbreviations
+
+   The following abbreviations used in this document:
+
+   DetNet        Deterministic Networking.
+
+   DF            DetNet Flow.
+
+   FRER          Frame Replication and Elimination for Redundancy (TSN
+                 function).
+
+   L2            Layer-2.
+
+   L3            Layer-3.
+
+   PREOF         Packet Replication, Ordering and Elimination Function.
+
+   TSN           Time-Sensitive Networking, TSN is a Task Group of the
+                 IEEE 802.1 Working Group.
+
+2.3.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+3.  DetNet IP Data Plane Overview
+
+   [I-D.ietf-detnet-ip] describes how IP is used by DetNet nodes, i.e.,
+   hosts and routers, to identify DetNet flows and provide a DetNet
+   service.  From a data plane perspective, an end-to-end IP model is
+   followed.  DetNet uses "6-tuple" based flow identification, where
+   "6-tuple" refers to information carried in IP and higher layer
+   protocol headers.
+
+
+
+
+Varga, et al.              Expires May 6, 2021                  [Page 3]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+   DetNet flow aggregation may be enabled via the use of wildcards,
+   masks, prefixes and ranges.  IP tunnels may also be used to support
+   flow aggregation.  In these cases, it is expected that DetNet aware
+   intermediate nodes will provide DetNet service assurance on the
+   aggregate through resource allocation and congestion control
+   mechanisms.
+
+   Congestion protection, latency control and the resource allocation
+   (queuing, policing, shaping) are supported using the underlying link
+   / sub-net specific mechanisms.  Service protections (packet
+   replication and packet elimination functions) are not provided at the
+   IP DetNet layer end-to-end due the lack of a unified end-to-end
+   sequencing information that would be available for intermediate
+   nodes.  However, such service protection can be provided on a per
+   underlying L2 link and sub-network basis.
+
+   DetNet routers ensure that DetNet service requirements are met per
+   hop by allocating local resources, both receive and transmit, and by
+   mapping the service requirements of each flow to appropriate sub-
+   network mechanisms.  Such mappings are sub-network technology
+   specific.  DetNet nodes interconnected by a TSN sub-network are the
+   primary focus of this document.  The mapping of DetNet IP flows to
+   TSN streams and TSN protection mechanisms are covered in Section 4.
+
+4.  DetNet IP Flows over an IEEE 802.1 TSN sub-network
+
+   This section covers how DetNet IP flows operate over an IEEE 802.1
+   TSN sub-network.  Figure 1 illustrates such a scenario, where two IP
+   (DetNet) nodes are interconnected by a TSN sub-network.  Dotted lines
+   around the Service components of the IP (DetNet) Nodes indicate that
+   they are DetNet service aware but do not perform any DetNet service
+   sub-layer function.  Node-1 is single homed and Node-2 is dual-homed
+   to the TSN sub-network.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Varga, et al.              Expires May 6, 2021                  [Page 4]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+       IP (DetNet)                   IP (DetNet)
+         Node-1                        Node-2
+
+      ............                  ............
+   <--: Service  :-- DetNet flow ---: Service  :-->
+      +----------+                  +----------+
+      |Forwarding|                  |Forwarding|
+      +--------.-+    <-TSN Str->   +-.-----.--+
+                \      ,-------.     /     /
+                 +----[ TSN-Sub ]---+     /
+                      [ Network ]--------+
+                       `-------'
+   <----------------- DetNet IP ----------------->
+
+      Figure 1: DetNet (DN) Enabled IP Network over a TSN sub-network
+
+   The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1
+   Working Group have defined (and are defining) a number of amendments
+   to IEEE 802.1Q [IEEE8021Q] that provide zero congestion loss and
+   bounded latency in bridged networks.  Furthermore, IEEE 802.1CB
+   [IEEE8021CB] defines frame replication and elimination functions for
+   reliability that should prove both compatible with and useful to
+   DetNet networks.  All these functions have to identify flows that
+   require TSN treatment.
+
+   TSN capabilities of the TSN sub-network are made available for IP
+   (DetNet) flows via the protocol interworking function desribed in
+   Annex C.5 of IEEE 802.1CB [IEEE8021CB].  For example, applied on the
+   TSN edge port it can convert an ingress unicast IP (DetNet) flow to
+   use a specific Layer-2 multicast destination MAC address and a VLAN,
+   in order to direct the packet through a specific path inside the
+   bridged network.  A similar interworking function pair at the other
+   end of the TSN sub-network would restore the packet to its original
+   Layer-2 destination MAC address and VLAN.
+
+   Placement of TSN functions depends on the TSN capabilities of nodes.
+   IP (DetNet) Nodes may or may not support TSN functions.  For a given
+   TSN Stream (i.e., a mapped DetNet flow) an IP (DetNet) node is
+   treated as a Talker or a Listener inside the TSN sub-network.
+
+4.1.  Functions for DetNet Flow to TSN Stream Mapping
+
+   Mapping of a DetNet IP flow to a TSN Stream is provided via the
+   combination of a passive and an active stream identification function
+   that operate at the frame level (Layer-2).  The passive stream
+   identification function is used to catch the 6-tuple of a DetNet IP
+   flow and the active stream identification function is used to modify
+   the Ethernet header according to the ID of the mapped TSN Stream.
+
+
+
+Varga, et al.              Expires May 6, 2021                  [Page 5]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+   Clause 6.7 of IEEE 802.1CB [IEEE8021CB] defines an IP Stream
+   identification function that can be used as a passive function for IP
+   DetNet flows using UDP or TCP.  Clause 6.8 of IEEE P802.1CBdb
+   [IEEEP8021CBdb] defines a Mask-and-Match Stream identification
+   function that can be used as a passive function for any IP DetNet
+   flows.
+
+   Clause 6.6 of IEEE 802.1CB [IEEE8021CB] defines an Active Destination
+   MAC and VLAN Stream identification function, what can replace some
+   Ethernet header fields namely (1) the destination MAC-address, (2)
+   the VLAN-ID and (3) priority parameters with alternate values.
+   Replacement is provided for the frame passed down the stack from the
+   upper layers or up the stack from the lower layers.
+
+   Active Destination MAC and VLAN Stream identification can be used
+   within a Talker to set flow identity or a Listener to recover the
+   original addressing information.  It can be used also in a TSN bridge
+   that is providing translation as a proxy service for an End System.
+
+4.2.  TSN requirements of IP DetNet nodes
+
+   This section covers required behavior of a TSN-aware DetNet node
+   using a TSN sub-network.  The implementation of TSN packet processing
+   functions must be compliant with the relevant IEEE 802.1 standards.
+
+   From the TSN sub-network perspective DetNet IP nodes are treated as
+   Talker or Listener, that may be (1) TSN-unaware or (2) TSN-aware.
+
+   In cases of TSN-unaware IP DetNet nodes the TSN relay nodes within
+   the TSN sub-network must modify the Ethernet encapsulation of the
+   DetNet IP flow (e.g., MAC translation, VLAN-ID setting, Sequence
+   number addition, etc.) to allow proper TSN specific handling inside
+   the sub-network.  There are no requirements defined for TSN-unaware
+   IP DetNet nodes in this document.
+
+   IP (DetNet) nodes being TSN-aware can be treated as a combination of
+   a TSN-unaware Talker/Listener and a TSN-Relay, as shown in Figure 2.
+   In such cases the IP (DetNet) node must provide the TSN sub-network
+   specific Ethernet encapsulation over the link(s) towards the sub-
+   network.
+
+
+
+
+
+
+
+
+
+
+
+Varga, et al.              Expires May 6, 2021                  [Page 6]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+                  IP (DetNet)
+                     Node
+      <---------------------------------->
+
+      ............
+   <--: Service  :-- DetNet flow ------------------
+      +----------+
+      |Forwarding|
+      +----------+    +---------------+
+      |    L2    |    | L2 Relay with |<--- TSN ---
+      |          |    | TSN function  |    Stream
+      +-----.----+    +--.------.---.-+
+             \__________/        \   \______
+                                  \_________
+       TSN-unaware
+        Talker /          TSN-Bridge
+        Listener             Relay
+                                          <----- TSN Sub-network -----
+      <------- TSN-aware Tlk/Lstn ------->
+
+               Figure 2: IP (DetNet) node with TSN functions
+
+   A TSN-aware IP (DetNet) node impementations must support the Stream
+   Identification TSN component for recognizing flows.
+
+   A Stream identification component must be able to instantiate the
+   following functions (1) Active Destination MAC and VLAN Stream
+   identification function, (2) IP Stream identification function, (3)
+   Mask-and-Match Stream identification function and (4) the related
+   managed objects in Clause 9 of IEEE 802.1CB [IEEE8021CB] and IEEE
+   P802.1CBdb [IEEEP8021CBdb].
+
+   A TSN-aware IP (DetNet) node implementations must support the
+   Sequencing function and the Sequence encode/decode function as
+   defined in Clause 7.4 and 7.6 of IEEE 802.1CB [IEEE8021CB] if FRER is
+   used inside the TSN sub-network.
+
+   The Sequence encode/decode function must support the Redundancy tag
+   (R-TAG) format as per Clause 7.8 of IEEE 802.1CB [IEEE8021CB].
+
+   A TSN-aware IP (DetNet) node implementations must support the Stream
+   splitting function and the Individual recovery function as defined in
+   Clause 7.7 and 7.5 of IEEE 802.1CB [IEEE8021CB] when the node is a
+   replication or elimination point for FRER.
+
+
+
+
+
+
+
+Varga, et al.              Expires May 6, 2021                  [Page 7]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+4.3.  Service protection within the TSN sub-network
+
+   TSN Streams supporting DetNet flows may use Frame Replication and
+   Elimination for Redundancy (FRER) as defined in Clause 8. of IEEE
+   802.1CB [IEEE8021CB] based on the loss service requirements of the
+   TSN Stream, which is derived from the DetNet service requirements of
+   the DetNet mapped flow.  The specific operation of FRER is not
+   modified by the use of DetNet and follows IEEE 802.1CB [IEEE8021CB].
+
+   FRER function and the provided service recovery is available only
+   within the TSN sub-network as the TSN Stream-ID and the TSN sequence
+   number are not valid outside the sub-network.  An IP (DetNet) node
+   represents a L3 border and as such it terminates all related
+   information elements encoded in the L2 frames.
+
+4.4.  Aggregation during DetNet flow to TSN Stream mapping
+
+   Implementations of this document shall use management and control
+   information to map a DetNet flow to a TSN Stream.  N:1 mapping
+   (aggregating DetNet flows in a single TSN Stream) shall be supported.
+   The management or control function that provisions flow mapping shall
+   ensure that adequate resources are allocated and configured to
+   provide proper service requirements of the mapped flows.
+
+5.  Management and Control Implications
+
+   DetNet flow and TSN Stream mapping related information are required
+   only for TSN-aware IP (DetNet) nodes.  From the Data Plane
+   perspective there is no practical difference based on the origin of
+   flow mapping related information (management plane or control plane).
+
+   The following summarizes the set of information that is needed to
+   configure DetNet IP over TSN:
+
+   o  DetNet IP related configuration information according to the
+      DetNet role of the DetNet IP node, as per [I-D.ietf-detnet-ip].
+
+   o  TSN related configuration information according to the TSN role of
+      the DetNet IP node, as per [IEEE8021Q], [IEEE8021CB] and
+      [IEEEP8021CBdb].
+
+   o  Mapping between DetNet IP flow(s) (as flow identification defined
+      in [I-D.ietf-detnet-ip], it is summarized in Section 5.1 of that
+      document, and includes all wildcards, port ranges and the ability
+      to ignore specific IP fields) and TSN Stream(s) (as stream
+      identification information defined in [IEEE8021CB] and
+      [IEEEP8021CBdb]).  Note, that managed objects for TSN Stream
+      identification can be found in [IEEEP8021CBcv].
+
+
+
+Varga, et al.              Expires May 6, 2021                  [Page 8]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+   This information must be provisioned per DetNet flow.
+
+   Mappings between DetNet and TSN management and control planes are out
+   of scope of the document.  Some of the challanges are highligthed
+   below.
+
+   TSN-aware IP DetNet nodes are member of both the DetNet domain and
+   the TSN sub-network.  Within the TSN sub-network the TSN-aware IP
+   (DetNet) node has a TSN-aware Talker/Listener role, so TSN specific
+   management and control plane functionalities must be implemented.
+   There are many similarities in the management plane techniques used
+   in DetNet and TSN, but that is not the case for the control plane
+   protocols.  For example, RSVP-TE and MSRP behaves differently.
+   Therefore management and control plane design is an important aspect
+   of scenarios, where mapping between DetNet and TSN is required.
+
+   In order to use a TSN sub-network between DetNet nodes, DetNet
+   specific information must be converted to TSN sub-network specific
+   ones.  DetNet flow ID and flow related parameters/requirements must
+   be converted to a TSN Stream ID and stream related parameters/
+   requirements.  Note that, as the TSN sub-network is just a portion of
+   the end-to-end DetNet path (i.e., single hop from IP perspective),
+   some parameters (e.g., delay) may differ significantly.  Other
+   parameters (like bandwidth) also may have to be tuned due to the L2
+   encapsulation used within the TSN sub-network.
+
+   In some case it may be challenging to determine some TSN Stream
+   related information.  For example, on a TSN-aware IP (DetNet) node
+   that acts as a Talker, it is quite obvious which DetNet node is the
+   Listener of the mapped TSN stream (i.e., the IP Next-Hop).  However
+   it may be not trivial to locate the point/interface where that
+   Listener is connected to the TSN sub-network.  Such attributes may
+   require interaction between control and management plane functions
+   and between DetNet and TSN domains.
+
+   Mapping between DetNet flow identifiers and TSN Stream identifiers,
+   if not provided explicitly, can be done by a TSN-aware IP (DetNet)
+   node locally based on information provided for configuration of the
+   TSN Stream identification functions (IP Stream identification, Mask-
+   and-match Stream identification and active Stream identification
+   function).
+
+   Triggering the setup/modification of a TSN Stream in the TSN sub-
+   network is an example where management and/or control plane
+   interactions are required between the DetNet and TSN sub-network.
+   TSN-unaware IP (DetNet) nodes make such a triggering even more
+   complicated as they are fully unaware of the sub-network and run
+   independently.
+
+
+
+Varga, et al.              Expires May 6, 2021                  [Page 9]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+   Configuration of TSN specific functions (e.g., FRER) inside the TSN
+   sub-network is a TSN domain specific decision and may not be visible
+   in the DetNet domain.
+
+6.  Security Considerations
+
+   Security considerations for DetNet are described in detail in
+   [I-D.ietf-detnet-security].  General security considerations are
+   described in [RFC8655].  DetNet IP data plane specific considerations
+   are summarized in [I-D.ietf-detnet-ip].  This section considers
+   exclusively security considerations which are specific to the DetNet
+   IP over TSN sub-network scenario.
+
+   The sub-network between DetNet nodes needs to be subject to
+   appropriate confidentiality.  Additionally, knowledge of what DetNet/
+   TSN services are provided by a sub-network may supply information
+   that can be used in a variety of security attacks.  The ability to
+   modify information exchanges between connected DetNet nodes may
+   result in bogus operations.  Therefore, it is important that the
+   interface between DetNet nodes and TSN sub-network are subject to
+   authorization, authentication, and encryption.
+
+   The TSN sub-network operates at Layer-2 so various security
+   mechanisms defined by IEEE can be used to secure the connection
+   between the DetNet nodes (e.g., encryption may be provided using
+   MACSec [IEEE802.1AE-2018]).
+
+7.  IANA Considerations
+
+   None.
+
+8.  Acknowledgements
+
+   The authors wish to thank Norman Finn, Lou Berger, Craig Gunther,
+   Christophe Mangin and Jouni Korhonen for their various contributions
+   to this work.
+
+9.  References
+
+9.1.  Normative references
+
+   [I-D.ietf-detnet-ip]
+              Varga, B., Farkas, J., Berger, L., Fedyk, D., and S.
+              Bryant, "DetNet Data Plane: IP", draft-ietf-detnet-ip-07
+              (work in progress), July 2020.
+
+
+
+
+
+
+Varga, et al.              Expires May 6, 2021                 [Page 10]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+9.2.  Informative references
+
+   [I-D.ietf-detnet-flow-information-model]
+              Varga, B., Farkas, J., Cummings, R., Jiang, Y., and D.
+              Fedyk, "DetNet Flow Information Model", draft-ietf-detnet-
+              flow-information-model-11 (work in progress), October
+              2020.
+
+   [I-D.ietf-detnet-security]
+              Grossman, E., Mizrahi, T., and A. Hacker, "Deterministic
+              Networking (DetNet) Security Considerations", draft-ietf-
+              detnet-security-12 (work in progress), October 2020.
+
+   [IEEE802.1AE-2018]
+              IEEE Standards Association, "IEEE Std 802.1AE-2018 MAC
+              Security (MACsec)", 2018,
+              <https://ieeexplore.ieee.org/document/8585421>.
+
+   [IEEE8021CB]
+              IEEE 802.1, "Standard for Local and metropolitan area
+              networks - Frame Replication and Elimination for
+              Reliability (IEEE Std 802.1CB-2017)", 2017,
+              <http://standards.ieee.org/about/get/>.
+
+   [IEEE8021Q]
+              IEEE 802.1, "Standard for Local and metropolitan area
+              networks--Bridges and Bridged Networks (IEEE Std 802.1Q-
+              2018)", 2018, <http://standards.ieee.org/about/get/>.
+
+   [IEEEP8021CBcv]
+              Kehrer, S., "FRER YANG Data Model and Management
+              Information Base Module", IEEE P802.1CBcv
+              /D0.4 P802.1CBcv, August 2020,
+              <https://www.ieee802.org/1/files/private/cv-drafts/
+              d0/802-1CBcv-d0-4.pdf>.
+
+
+
+
+
+
+
+Varga, et al.              Expires May 6, 2021                 [Page 11]
+
+Internet-Draft             DetNet IP over TSN              November 2020
+
+
+   [IEEEP8021CBdb]
+              Mangin, C., "Extended Stream identification functions",
+              IEEE P802.1CBdb /D1.0 P802.1CBdb, September 2020,
+              <http://www.ieee802.org/1/files/private/db-drafts/
+              d1/802-1CBdb-d1-0.pdf>.
+
+   [RFC8655]  Finn, N., Thubert, P., Varga, B., and J. Farkas,
+              "Deterministic Networking Architecture", RFC 8655,
+              DOI 10.17487/RFC8655, October 2019,
+              <https://www.rfc-editor.org/info/rfc8655>.
+
+Authors' Addresses
+
+   Balazs Varga (editor)
+   Ericsson
+   Magyar Tudosok krt. 11.
+   Budapest  1117
+   Hungary
+
+   Email: balazs.a.varga@ericsson.com
+
+
+   Janos Farkas
+   Ericsson
+   Magyar Tudosok krt. 11.
+   Budapest  1117
+   Hungary
+
+   Email: janos.farkas@ericsson.com
+
+
+   Andrew G. Malis
+   Malis Consulting
+
+   Email: agmalis@gmail.com
+
+
+   Stewart Bryant
+   Futurewei Technologies
+
+   Email: stewart.bryant@gmail.com
+
+
+
+
+
+
+
+
+
+
+Varga, et al.              Expires May 6, 2021                 [Page 12]

--- a/ip-over-tsn/IDs/draft-ietf-detnet-ip-over-tsn-04.xml
+++ b/ip-over-tsn/IDs/draft-ietf-detnet-ip-over-tsn-04.xml
@@ -1,0 +1,623 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+]>
+<?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
+<?rfc toc="yes"?>
+<?rfc symrefs="yes"?>
+<?rfc sortrefs="yes"?>
+<?rfc iprnotified="no"?>
+<?rfc strict="yes"?>
+<?rfc compact="yes"?>
+<?rfc subcompact="no"?>
+<rfc category="info"
+     docName="draft-ietf-detnet-ip-over-tsn-04"
+     ipr="trust200902"
+     submissionType="IETF">
+  <front>
+    <title abbrev="DetNet IP over TSN">
+    DetNet Data Plane: IP over IEEE 802.1 Time Sensitive Networking (TSN)</title>
+
+    <author role="editor" fullname="Bal&aacute;zs Varga" initials="B." surname="Varga">
+      <organization>Ericsson</organization>
+      <address>
+        <postal>
+          <street>Magyar Tudosok krt. 11.</street>
+          <city>Budapest</city>
+          <country>Hungary</country>
+          <code>1117</code>
+        </postal>
+        <email>balazs.a.varga@ericsson.com</email>
+      </address>
+    </author>
+
+    <author fullname="J&aacute;nos Farkas" initials="J." surname="Farkas">
+      <organization>Ericsson</organization>
+      <address>
+        <postal>
+          <street>Magyar Tudosok krt. 11.</street>
+          <city>Budapest</city>
+          <country>Hungary</country>
+          <code>1117</code>
+        </postal>
+        <email>janos.farkas@ericsson.com</email>
+      </address>
+    </author>
+
+    <author fullname="Andrew G. Malis" initials="A.G." surname="Malis">
+      <organization>Malis Consulting</organization>
+      <address>
+        <email>agmalis@gmail.com</email>
+      </address>
+    </author>
+
+    <author fullname="Stewart Bryant" initials="S." surname="Bryant">
+      <organization>Futurewei Technologies</organization>
+      <address>
+        <email>stewart.bryant@gmail.com</email>
+      </address>
+    </author>
+
+    <date />
+    <workgroup>DetNet</workgroup>
+
+    <abstract>
+      <t>
+     This document specifies the Deterministic Networking IP data plane
+     when operating over a TSN sub-network. This document does not define 
+	 new procedures or processes.  Whenever this document makes requirements 
+	 statements or recommendations, these are taken from normative text in the 
+	 referenced RFCs.	 
+      </t>
+    </abstract>
+  </front>
+
+  <middle>
+    <section title="Introduction" anchor="sec_intro">
+      <t>
+        Deterministic Networking (DetNet) is a service that can be offered by a network to DetNet flows.
+        DetNet provides these flows extremely low packet loss rates and assured maximum end-to-end
+        delivery latency.  General background and concepts of DetNet can
+        be found in the DetNet Architecture <xref target="RFC8655"/>.
+      </t>
+      <t>
+        <xref target="I-D.ietf-detnet-ip"/> specifies the DetNet data plane operation for IP
+        hosts and routers that provide DetNet service to IP encapsulated
+        data.  This document focuses on the scenario where DetNet IP nodes
+		are interconnected by a TSN sub-network.
+      </t>
+      <t>
+        The DetNet Architecture decomposes the DetNet related data plane
+        functions into two sub-layers: a service sub-layer and a forwarding
+        sub-layer.  The service sub-layer is used to provide DetNet service
+        protection and reordering. The forwarding sub-layer is used to
+        provides congestion protection (low loss, assured latency, and
+        limited reordering). As described in <xref target="I-D.ietf-detnet-ip"/> 
+		no DetNet specific headers are added to
+        support DetNet IP flows, only the forwarding sub-layer functions are
+        supported inside the DetNet domain. Service
+        protection can be provided on a per sub-network
+        basis as shown here for the IEEE802.1 TSN sub-network scenario.
+      </t>
+    </section>
+
+    <section title="Terminology">
+
+      <section title="Terms Used In This Document">
+        <t>
+          This document uses the terminology and concepts established in
+          the DetNet architecture <xref
+          target="RFC8655"/>, and the reader is assumed
+          to be familiar with that document and its terminology.
+        </t>
+      </section>
+
+      <section title="Abbreviations">
+        <t>
+          The following abbreviations used in this document:
+          <list style="hanging" hangIndent="14">
+            <t hangText="DetNet">Deterministic Networking.</t>
+            <t hangText="DF">DetNet Flow.</t>
+			<t hangText="FRER">Frame Replication and Elimination for Redundancy 
+			(TSN function).</t>
+            <t hangText="L2">Layer-2.</t>
+            <t hangText="L3">Layer-3.</t>
+            <t hangText="PREOF">Packet Replication, Ordering and Elimination Function.</t>
+            <t hangText="TSN">Time-Sensitive Networking, TSN is a Task Group of the IEEE
+            802.1 Working Group.</t>
+          </list>
+        </t>
+      </section>
+
+	  <section title="Requirements Language">
+      <t>
+        The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+        NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
+        "MAY", and "OPTIONAL" in this document are to be interpreted as
+        described in BCP 14 <xref target="RFC2119"/> <xref
+        target="RFC8174"/> when, and only when, they appear in all
+        capitals, as shown here.
+      </t>
+	  </section>
+</section>
+
+<section title="DetNet IP Data Plane Overview" anchor="sec_dt_dp">
+      <t>
+        <xref target="I-D.ietf-detnet-ip"/> describes how IP is used by DetNet 
+		nodes, i.e., hosts and routers, to identify DetNet flows and provide a 
+		DetNet service. From a data plane perspective, an end-to-end IP model
+        is followed.  DetNet uses "6-tuple" based flow identification, where 
+		"6-tuple" refers to information carried in IP and higher layer protocol
+        headers. 
+      </t>
+      <t>
+        DetNet flow aggregation may be enabled via the use of
+        wildcards, masks, prefixes and ranges. IP tunnels may also be
+        used to support flow aggregation. In these cases, it is
+        expected that DetNet aware intermediate nodes will provide
+        DetNet service assurance on the aggregate through resource
+        allocation and congestion control mechanisms.
+      </t>
+	  <t>
+        Congestion protection, latency control and the resource allocation 
+		(queuing, policing, shaping) are supported using the underlying link 
+		/ sub-net specific mechanisms.  Service protections (packet
+        replication and packet elimination functions) are not provided at
+		the IP DetNet layer end-to-end due the lack of a unified end-to-end 
+		sequencing information that would be available for intermediate nodes.  
+		However, such service protection can be provided on a per underlying 
+		L2 link and sub-network basis.
+	  </t>
+      <t>
+	    DetNet routers ensure that DetNet service requirements are met per hop 
+		by allocating local resources, both receive and transmit, and by mapping 
+		the service requirements of each flow to appropriate sub-network 
+		mechanisms.  Such mappings are sub-network technology specific.  
+		DetNet nodes interconnected by a TSN sub-network are the primary focus 
+		of this document. 
+		The mapping of DetNet IP flows to TSN streams and TSN protection 
+		mechanisms are covered in <xref target="mapping-tsn"/>.
+      </t>
+
+    </section>
+
+    <!-- ===================================================================== -->
+
+
+    <section anchor="mapping-tsn" title="DetNet IP Flows over an IEEE 802.1 
+	TSN sub-network">
+      <t>
+        This section covers how DetNet IP flows operate over an IEEE 802.1 TSN
+        sub-network.  <xref target="fig_ip_detnet_to_tsn"/> illustrates such a
+        scenario, where two IP (DetNet) nodes are interconnected by a TSN
+        sub-network. 
+		Dotted lines around the Service components of the IP (DetNet) Nodes 
+		indicate that they are DetNet service aware but do not perform any 
+		DetNet service sub-layer function.		
+		Node-1 is single homed and Node-2 is dual-homed to the TSN
+		sub-network.  
+      </t>
+
+<figure align="center" anchor="fig_ip_detnet_to_tsn"
+              title="DetNet (DN) Enabled IP Network over a TSN sub-network">
+<artwork><![CDATA[
+    IP (DetNet)                   IP (DetNet)
+      Node-1                        Node-2
+
+   ............                  ............
+<--: Service  :-- DetNet flow ---: Service  :-->
+   +----------+                  +----------+
+   |Forwarding|                  |Forwarding|
+   +--------.-+    <-TSN Str->   +-.-----.--+
+             \      ,-------.     /     /
+              +----[ TSN-Sub ]---+     /
+                   [ Network ]--------+
+                    `-------'
+<----------------- DetNet IP ----------------->
+]]></artwork>
+      </figure>
+
+      <t>
+        The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1
+        Working Group have defined (and are defining) a number of
+        amendments to <xref target="IEEE8021Q">IEEE 802.1Q</xref> that
+        provide zero congestion loss and bounded latency in bridged
+        networks. Furthermore, <xref target="IEEE8021CB">IEEE
+        802.1CB</xref> defines frame replication and elimination
+        functions for reliability that should prove both compatible with
+        and useful to DetNet networks.  All these functions have to
+        identify flows that require TSN treatment.  
+	  </t>
+      <t>
+        TSN capabilities of the TSN sub-network are made available for IP
+        (DetNet) flows via the protocol interworking function desribed in Annex C.5 of
+        <xref target="IEEE8021CB">IEEE 802.1CB</xref>. For example,
+        applied on the TSN edge port it can convert an ingress unicast 
+		IP (DetNet) flow to use a specific Layer-2 multicast destination 
+		MAC address and a VLAN, in order to direct the packet through a 
+		specific path inside the bridged network. 
+		A similar interworking function pair at the 
+		other end of the TSN sub-network would restore the packet to its 
+		original Layer-2 destination MAC address and VLAN.
+      </t>
+      <t>
+        Placement of TSN functions depends on the TSN capabilities of
+        nodes. IP (DetNet) Nodes may or may not support TSN functions. For
+        a given TSN Stream (i.e., a mapped DetNet flow) an IP (DetNet) node is
+        treated as a Talker or a Listener inside the TSN sub-network.
+      </t>
+
+          <section title="Functions for DetNet Flow to TSN Stream Mapping">
+            <t>
+              Mapping of a DetNet IP flow to a TSN Stream is provided via 
+			  the combination of a passive and an active stream identification 
+			  function that operate at the frame level (Layer-2). The passive stream
+			  identification function is used to catch the 6-tuple of a DetNet
+			  IP flow and the active stream identification function is used to
+			  modify the Ethernet header according to the ID of the mapped TSN 
+			  Stream.  
+            </t>
+            <t>
+			  Clause 6.7 of <xref target="IEEE8021CB">IEEE 802.1CB</xref> defines an IP Stream
+			  identification function that can be used as a passive function
+			  for IP DetNet flows using UDP or TCP. Clause 6.8 of
+			  <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref> defines a
+			  Mask-and-Match Stream identification function that can be used 
+			  as a passive function for any IP DetNet flows.
+            </t>
+            <t>
+			  Clause 6.6 of <xref target="IEEE8021CB">IEEE 802.1CB</xref> defines an
+              Active Destination MAC and VLAN Stream identification function,
+              what can replace some Ethernet header fields namely (1) the
+              destination MAC-address, (2) the VLAN-ID and (3) priority
+              parameters with alternate values. Replacement is provided for
+              the frame passed down the stack from the upper layers or up the
+              stack from the lower layers.
+            </t>
+            <t>
+              Active Destination MAC and VLAN Stream identification can be
+              used within a Talker to set flow identity or a Listener to
+              recover the original addressing information. It can be used also
+              in a TSN bridge that is providing translation as a proxy service
+              for an End System. 
+            </t>
+		  </section>
+
+          <section title="TSN requirements of IP DetNet nodes">
+            <t>
+              This section covers required behavior of a TSN-aware DetNet node 
+			  using a TSN sub-network. The implementation of TSN packet 
+			  processing functions must be compliant with the relevant IEEE 802.1 
+			  standards.
+            </t>
+            <t>
+              From the TSN sub-network perspective DetNet IP nodes are treated 
+			  as Talker or Listener, that may be (1) TSN-unaware or 
+			  (2) TSN-aware.
+            </t>
+            <t>
+              In cases of TSN-unaware IP DetNet nodes the TSN relay nodes within
+			  the TSN sub-network must modify the Ethernet encapsulation of the 
+			  DetNet IP flow (e.g., MAC translation, VLAN-ID setting, Sequence 
+			  number addition, etc.) to allow proper TSN specific handling 
+			  inside the sub-network.  There are no requirements defined for 
+			  TSN-unaware IP DetNet nodes in this document.
+            </t>
+            <t>
+              IP (DetNet) nodes being TSN-aware can be treated as a
+              combination of a TSN-unaware Talker/Listener and a TSN-Relay, as
+              shown in <xref target="fig_ip_with_tsn"/>.  In such cases the IP
+              (DetNet) node must provide the TSN sub-network specific Ethernet
+              encapsulation over the link(s) towards the sub-network. 
+            </t>
+			  
+            <figure align="center" anchor="fig_ip_with_tsn"
+                    title="IP (DetNet) node with TSN functions">
+              <artwork><![CDATA[
+               IP (DetNet)
+                  Node
+   <---------------------------------->
+
+   ............
+<--: Service  :-- DetNet flow ------------------
+   +----------+
+   |Forwarding|
+   +----------+    +---------------+
+   |    L2    |    | L2 Relay with |<--- TSN ---
+   |          |    | TSN function  |    Stream
+   +-----.----+    +--.------.---.-+
+          \__________/        \   \______
+                               \_________
+    TSN-unaware
+     Talker /          TSN-Bridge
+     Listener             Relay
+                                       <----- TSN Sub-network -----
+   <------- TSN-aware Tlk/Lstn ------->
+]]></artwork>
+            </figure>
+
+            <t>
+			  A TSN-aware IP (DetNet) node impementations must support the 
+			  Stream Identification TSN component for recognizing flows.
+            </t>
+            <t>
+              A Stream identification component must be able to instantiate
+              the following functions (1) Active Destination MAC and VLAN
+              Stream identification function, (2) IP Stream identification
+              function, (3) Mask-and-Match Stream identification function and 
+			  (4) the related managed objects in Clause 9 of
+              <xref target="IEEE8021CB">IEEE 802.1CB</xref> and 
+			  <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref>.
+            </t>
+            <t>
+			  A TSN-aware IP (DetNet) node implementations must support the 
+			  Sequencing function and the Sequence encode/decode function as 
+			  defined in Clause 7.4 and 7.6 of <xref target="IEEE8021CB">IEEE 802.1CB</xref> if FRER 
+			  is used inside the TSN sub-network.
+            </t>
+            <t>
+              The Sequence encode/decode function must support the Redundancy
+              tag (R-TAG) format as per Clause 7.8 of <xref
+              target="IEEE8021CB">IEEE 802.1CB</xref>.
+            </t>
+            <t>
+			  A TSN-aware IP (DetNet) node implementations must support the 
+			  Stream splitting 
+			  function and the Individual recovery function as defined in Clause 7.7 and 7.5 of
+			  <xref target="IEEE8021CB">IEEE 802.1CB</xref> when the node is 
+			  a replication or elimination point for FRER.
+            </t>
+          </section>
+
+          <section title="Service protection within the TSN sub-network">
+            <t>
+              TSN Streams supporting DetNet flows may use Frame Replication
+              and Elimination for Redundancy (FRER) as defined in Clause 8. of
+			  <xref target="IEEE8021CB">IEEE 802.1CB</xref> based on the
+              loss service requirements of the TSN Stream, which is derived
+              from the DetNet service requirements of the DetNet mapped flow.
+              The specific operation of FRER is not modified by the use of
+              DetNet and follows <xref target="IEEE8021CB">IEEE
+              802.1CB</xref>.
+            </t>
+            <t>
+              FRER function and the provided service recovery is available
+              only within the TSN sub-network as the TSN Stream-ID and the TSN
+              sequence number are not valid outside the sub-network.  An IP
+              (DetNet) node represents a L3 border and as such it terminates
+              all related information elements encoded in the L2 frames.
+            </t>
+          </section>
+
+          <section title="Aggregation during DetNet flow to TSN Stream mapping">
+            <t>
+			Implementations of this document shall use management and
+			control information to map a DetNet flow to a TSN
+			Stream. N:1 mapping (aggregating DetNet flows in a single
+			TSN Stream) shall be supported. The management or control
+			function that provisions flow mapping shall ensure that
+			adequate resources are allocated and configured to provide
+			proper service requirements of the mapped flows.
+            </t>
+          </section>
+</section>
+
+<section title="Management and Control Implications">
+        <t>
+			DetNet flow and TSN Stream mapping related information are
+			required only for TSN-aware IP (DetNet) nodes. From the
+			Data Plane perspective there is no practical difference
+			based on the origin of flow mapping related information
+			(management plane or control plane).
+        </t>
+        <t>
+            The following summarizes the set of information that is needed to
+            configure DetNet IP over TSN:
+            <list style="symbols">
+			  <t>DetNet IP related configuration information according to the 
+			     DetNet role of the DetNet IP node, as per 
+			     <xref target="I-D.ietf-detnet-ip"/>. </t>
+			  <t>TSN related configuration information according to the 
+			     TSN role of the DetNet IP node, as per 
+				 <xref target="IEEE8021Q"/>, <xref target="IEEE8021CB"/> and
+			     <xref target="IEEEP8021CBdb"/>. </t>
+              <t>Mapping between DetNet IP flow(s) (as flow identification 
+			  defined in <xref target="I-D.ietf-detnet-ip"/>, it is summarized 
+			  in Section 5.1 of that document, and includes all wildcards, port 
+			  ranges and the ability to ignore specific IP fields) and TSN 
+			  Stream(s) (as stream identification information defined in 
+			  <xref target="IEEE8021CB"/> and <xref target="IEEEP8021CBdb"/>). 
+			  Note, that managed objects for TSN Stream identification can be 
+			  found in <xref target="IEEEP8021CBcv"/>.
+			  </t>
+            </list>
+            This information must be provisioned per DetNet flow.
+        </t>
+        <t>
+			Mappings between DetNet and TSN management and control planes are 
+			out of scope of the document. Some of the challanges are 
+			highligthed below.
+        </t>
+		<t>
+			TSN-aware IP DetNet nodes are member of both the DetNet
+			domain and the TSN sub-network.  Within the TSN
+			sub-network the TSN-aware IP (DetNet) node has a TSN-aware
+			Talker/Listener role, so TSN specific management and
+			control plane functionalities must be implemented.  There
+			are many similarities in the management plane techniques
+			used in DetNet and TSN, but that is not the case for the
+			control plane protocols. For example, RSVP-TE and MSRP
+			behaves differently. Therefore management and control
+			plane design is an important aspect of scenarios, where
+			mapping between DetNet and TSN is required.
+	    </t>
+	    <t>
+	      In order to use a TSN sub-network between DetNet nodes,
+	      DetNet specific information must be converted to TSN
+	      sub-network specific ones. DetNet flow ID and flow related
+	      parameters/requirements must be converted to a TSN Stream
+	      ID and stream related parameters/requirements. Note that,
+	      as the TSN sub-network is just a portion of the end-to-end
+	      DetNet path (i.e., single hop from IP perspective), some
+	      parameters (e.g., delay) may differ significantly. Other
+	      parameters (like bandwidth) also may have to be tuned due
+	      to the L2 encapsulation used within the TSN sub-network.
+	    </t>
+	    <t>
+	      In some case it may be challenging to determine some TSN
+	      Stream related information. For example, on a TSN-aware IP
+	      (DetNet) node that acts as a Talker, it is quite obvious
+	      which DetNet node is the Listener of the mapped TSN stream
+	      (i.e., the IP Next-Hop). However it may be not trivial to
+	      locate the point/interface where that Listener is
+	      connected to the TSN sub-network. Such attributes may
+	      require interaction between control and management plane
+	      functions and between DetNet and TSN domains.
+	    </t>
+        <t>
+	      Mapping between DetNet flow identifiers and TSN Stream
+	      identifiers, if not provided explicitly, can be done by a
+	      TSN-aware IP (DetNet) node locally based on information
+	      provided for configuration of the TSN Stream
+	      identification functions (IP Stream identification, 
+		  Mask-and-match Stream identification and active Stream 
+		  identification function).
+	    </t>
+	    <t>
+	      Triggering the setup/modification of a TSN Stream in the
+	      TSN sub-network is an example where management and/or
+	      control plane interactions are required between the DetNet
+	      and TSN sub-network. TSN-unaware IP (DetNet) nodes make
+	      such a triggering even more complicated as they are fully
+	      unaware of the sub-network and run independently.
+	    </t>
+	    <t>
+	      Configuration of TSN specific functions (e.g., FRER)
+	      inside the TSN sub-network is a TSN domain specific decision 
+		  and may not be visible in the DetNet domain.
+	    </t>
+</section>
+
+
+    <!-- ===================================================================== -->
+
+    <section title="Security Considerations">
+      <t>
+	  Security considerations for DetNet are described in detail in
+	  <xref target="I-D.ietf-detnet-security"/>. General security considerations
+      are described in <xref target="RFC8655"/>. 
+	  DetNet IP data plane specific considerations are summarized in 
+	  <xref target="I-D.ietf-detnet-ip"/>. 
+	  This section considers exclusively security considerations which are 
+	  specific to the DetNet IP over TSN sub-network scenario.
+      </t>
+      <t>
+	  The sub-network between DetNet nodes needs to be subject to appropriate 
+	  confidentiality. Additionally, knowledge of what DetNet/TSN services are 
+	  provided by a sub-network may supply information that can be used in a 
+	  variety of security attacks. The ability to modify information exchanges 
+	  between connected DetNet nodes may result in bogus operations. Therefore, 
+	  it is important that the interface between DetNet nodes and TSN 
+	  sub-network are subject to authorization, authentication, and encryption.
+      </t>
+      <t>
+	  The TSN sub-network operates at Layer-2 so various security mechanisms 
+	  defined by IEEE can be used to secure the connection between the DetNet 
+	  nodes (e.g., encryption may be provided using MACSec 
+	  <xref target="IEEE802.1AE-2018"/>).
+      </t>
+    </section>
+
+
+    <section anchor="iana" title="IANA Considerations">
+      <t>
+		None.
+      </t>
+    </section>
+
+    <section anchor="acks" title="Acknowledgements">
+      <t>
+		The authors wish to thank Norman Finn, Lou Berger, Craig Gunther,
+		Christophe Mangin and Jouni Korhonen for their various contributions 
+		to this work.
+      </t>
+    </section>
+  </middle>
+
+  <back>
+    <references title="Normative references">
+      <?rfc include="reference.RFC.2119"?>
+      <?rfc include="reference.RFC.8174"?>
+      <?rfc include="reference.I-D.ietf-detnet-ip"?>
+    </references>
+    <references title="Informative references">
+      <?rfc include="reference.RFC.8655"?>
+      <?rfc include="reference.I-D.ietf-detnet-flow-information-model"?>
+      <?rfc include="reference.I-D.ietf-detnet-security"?>
+
+    <reference anchor="IEEE802.1AE-2018"
+      target="https://ieeexplore.ieee.org/document/8585421">
+      <front>
+        <title>IEEE Std 802.1AE-2018 MAC Security (MACsec)</title>
+        <author>
+          <organization>IEEE Standards Association</organization>
+        </author>
+        <date year="2018" />
+      </front>
+    </reference>
+
+      <reference anchor="IEEE8021Q"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks--Bridges
+          and Bridged Networks (IEEE Std 802.1Q-2018)</title>
+          <author>
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date year="2018"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
+
+      <reference anchor="IEEE8021CB"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks - 
+		  Frame Replication and Elimination for Reliability 
+		  (IEEE Std 802.1CB-2017)</title>
+          <author>
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date year="2017"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
+
+      <reference anchor="IEEEP8021CBdb"
+                 target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf">
+        <front>
+          <title>Extended Stream identification functions</title>
+          <author initials="C. M." surname="Mangin" fullname="Christophe Mangin">
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date month="September" year="2020"/>
+        </front>
+        <seriesInfo name="IEEE P802.1CBdb /D1.0" value="P802.1CBdb"/>
+        <format type="PDF" target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf"/>
+      </reference>
+
+      <reference anchor="IEEEP8021CBcv"
+                 target="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf">
+        <front>
+          <title>FRER YANG Data Model and Management Information Base Module</title>
+          <author initials="S." surname="Kehrer" fullname="Stephan Kehrer">
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date month="August" year="2020"/>
+        </front>
+        <seriesInfo name="IEEE P802.1CBcv /D0.4" value="P802.1CBcv"/>
+        <format type="PDF" target="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf"/>
+      </reference>
+    </references>
+
+  </back>
+</rfc>

--- a/ip-over-tsn/draft-ietf-detnet-ip-over-tsn.xml
+++ b/ip-over-tsn/draft-ietf-detnet-ip-over-tsn.xml
@@ -9,7 +9,7 @@
 <?rfc strict="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
-<rfc category="std"
+<rfc category="info"
      docName="draft-ietf-detnet-ip-over-tsn-04"
      ipr="trust200902"
      submissionType="IETF">
@@ -63,7 +63,10 @@
     <abstract>
       <t>
      This document specifies the Deterministic Networking IP data plane
-     when operating over a TSN sub-network.
+     when operating over a TSN sub-network. This document does not define 
+	 new procedures or processes.  Whenever this document makes requirements 
+	 statements or recommendations, these are taken from normative text in the 
+	 referenced RFCs.	 
       </t>
     </abstract>
   </front>
@@ -159,52 +162,18 @@
 		(queuing, policing, shaping) are supported using the underlying link 
 		/ sub-net specific mechanisms.  Service protections (packet
         replication and packet elimination functions) are not provided at
-		the DetNet layer end-to-end due the lack of a unified end-to-end 
+		the IP DetNet layer end-to-end due the lack of a unified end-to-end 
 		sequencing information that would be available for intermediate nodes.  
 		However, such service protection can be provided on a per underlying 
 		L2 link and sub-network basis.
 	  </t>
-
-      <figure align="center" anchor="fig_ip_detnet_part"
-              title="Part of a Simple DetNet (DN) Enabled IP Network using a TSN sub-net">
-        <artwork><![CDATA[
-      Edge          Transit        Relay       
-      Node            Node         Node        
-
-   +.........+                                 
-<--:Svc Proxy:-- End to End Service ----------->
-   +-----....+                   +..........+   
-   |IP | :Svc:<-- DetNet flow ---: Service :--->
-   +---+ +---+    +---------+    +---------+   
-   |Fwd| |Fwd|    |   Fwd   |    |Fwd| |Fwd|   
-   +-.-+ +-.-+    +--.----.-+    +-.-+ +-.-+   
-     :    /  ,-----.  \   :  Link  :     :
-.....+    +-[TSN Sub]-+   +........+     +.....
-            [Network]                
-             `-----'                
-         <------------- DetNet IP -------------
-                         ]]></artwork>
-      </figure>
-      <t>
-        <xref target="fig_ip_detnet_part"/> illustrates an extract of a DetNet 
-		enabled IP network, that uses a TSN sub-network as interconnection between
-		two DetNet Nodes.  In this figure, an Edge Node sits at the boundary of 
-		the DetNet domain and provide DetNet service proxies for the end 
-		applications by initiating and terminating DetNet service for the 
-		application's IP flows.  Node and interface resources are allocated to 
-		ensure DetNet service requirements. 
-		Dotted lines around the Service components of the Edge and Relay Nodes 
-		indicate that they are DetNet service aware but do not perform any 
-		DetNet service sub-layer function, e.g., PREOF (Packet Replication, 
-		Elimination, and Ordering Functions).  In this example the 
-		Edge Node and the Transit Node are interconnected by a TSN sub-network, 
-		being the primary focus of this document. 
-      </t>
       <t>
 	    DetNet routers ensure that DetNet service requirements are met per hop 
 		by allocating local resources, both receive and transmit, and by mapping 
 		the service requirements of each flow to appropriate sub-network 
 		mechanisms.  Such mappings are sub-network technology specific.  
+		DetNet nodes interconnected by a TSN sub-network are the primary focus 
+		of this document. 
 		The mapping of DetNet IP flows to TSN streams and TSN protection 
 		mechanisms are covered in <xref target="mapping-tsn"/>.
       </t>
@@ -220,7 +189,11 @@
         This section covers how DetNet IP flows operate over an IEEE 802.1 TSN
         sub-network.  <xref target="fig_ip_detnet_to_tsn"/> illustrates such a
         scenario, where two IP (DetNet) nodes are interconnected by a TSN
-        sub-network. Node-1 is single homed and Node-2 is dual-homed to the TSN
+        sub-network. 
+		Dotted lines around the Service components of the IP (DetNet) Nodes 
+		indicate that they are DetNet service aware but do not perform any 
+		DetNet service sub-layer function.		
+		Node-1 is single homed and Node-2 is dual-homed to the TSN
 		sub-network.  
       </t>
 
@@ -313,7 +286,7 @@
             <t>
               This section covers required behavior of a TSN-aware DetNet node 
 			  using a TSN sub-network. The implementation of TSN packet 
-			  processing functions MUST be compliant with the relevant IEEE 802.1 
+			  processing functions must be compliant with the relevant IEEE 802.1 
 			  standards.
             </t>
             <t>
@@ -363,11 +336,11 @@
             </figure>
 
             <t>
-			  A TSN-aware IP (DetNet) node impementations MUST support the 
+			  A TSN-aware IP (DetNet) node impementations must support the 
 			  Stream Identification TSN component for recognizing flows.
             </t>
             <t>
-              A Stream identification component MUST be able to instantiate
+              A Stream identification component must be able to instantiate
               the following functions (1) Active Destination MAC and VLAN
               Stream identification function, (2) IP Stream identification
               function, (3) Mask-and-Match Stream identification function and 
@@ -376,18 +349,18 @@
 			  <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref>.
             </t>
             <t>
-			  A TSN-aware IP (DetNet) node implementations MUST support the 
+			  A TSN-aware IP (DetNet) node implementations must support the 
 			  Sequencing function and the Sequence encode/decode function as 
 			  defined in Clause 7.4 and 7.6 of <xref target="IEEE8021CB">IEEE 802.1CB</xref> if FRER 
 			  is used inside the TSN sub-network.
             </t>
             <t>
-              The Sequence encode/decode function MUST support the Redundancy
+              The Sequence encode/decode function must support the Redundancy
               tag (R-TAG) format as per Clause 7.8 of <xref
               target="IEEE8021CB">IEEE 802.1CB</xref>.
             </t>
             <t>
-			  A TSN-aware IP (DetNet) node implementations MUST support the 
+			  A TSN-aware IP (DetNet) node implementations must support the 
 			  Stream splitting 
 			  function and the Individual recovery function as defined in Clause 7.7 and 7.5 of
 			  <xref target="IEEE8021CB">IEEE 802.1CB</xref> when the node is 
@@ -417,11 +390,11 @@
 
           <section title="Aggregation during DetNet flow to TSN Stream mapping">
             <t>
-			Implementations of this document SHALL use management and
+			Implementations of this document shall use management and
 			control information to map a DetNet flow to a TSN
 			Stream. N:1 mapping (aggregating DetNet flows in a single
-			TSN Stream) SHALL be supported. The management or control
-			function that provisions flow mapping SHALL ensure that
+			TSN Stream) shall be supported. The management or control
+			function that provisions flow mapping shall ensure that
 			adequate resources are allocated and configured to provide
 			proper service requirements of the mapped flows.
             </t>
@@ -457,9 +430,14 @@
 			  found in <xref target="IEEEP8021CBcv"/>.
 			  </t>
             </list>
-            This information MUST be provisioned per DetNet flow.
+            This information must be provisioned per DetNet flow.
         </t>
         <t>
+			Mappings between DetNet and TSN management and control planes are 
+			out of scope of the document. Some of the challanges are 
+			highligthed below.
+        </t>
+		<t>
 			TSN-aware IP DetNet nodes are member of both the DetNet
 			domain and the TSN sub-network.  Within the TSN
 			sub-network the TSN-aware IP (DetNet) node has a TSN-aware
@@ -591,53 +569,53 @@
                  target="http://standards.ieee.org/about/get/">
         <front>
           <title>Standard for Local and metropolitan area networks--Bridges
-          and Bridged Networks (IEEE Std 802.1Q-2014)</title>
+          and Bridged Networks (IEEE Std 802.1Q-2018)</title>
           <author>
             <organization>IEEE 802.1</organization>
           </author>
-          <date year="2014"/>
+          <date year="2018"/>
         </front>
         <format type="PDF" target="http://standards.ieee.org/about/get/"/>
       </reference>
 
       <reference anchor="IEEE8021CB"
-                 target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf">
+                 target="http://standards.ieee.org/about/get/">
         <front>
-          <title>Draft Standard for Local and metropolitan area networks -
-          Seamless Redundancy</title>
-          <author initials="N. F." surname="Finn" fullname="Norman Finn">
+          <title>Standard for Local and metropolitan area networks - 
+		  Frame Replication and Elimination for Reliability 
+		  (IEEE Std 802.1CB-2017)</title>
+          <author>
             <organization>IEEE 802.1</organization>
           </author>
-          <date month="December" year="2015"/>
+          <date year="2017"/>
         </front>
-        <seriesInfo name="IEEE P802.1CB /D2.1" value="P802.1CB"/>
-        <format type="PDF" target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf"/>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
       </reference>
 
       <reference anchor="IEEEP8021CBdb"
-                 target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf">
+                 target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf">
         <front>
           <title>Extended Stream identification functions</title>
           <author initials="C. M." surname="Mangin" fullname="Christophe Mangin">
             <organization>IEEE 802.1</organization>
           </author>
-          <date month="August" year="2019"/>
+          <date month="September" year="2020"/>
         </front>
-        <seriesInfo name="IEEE P802.1CBdb /D0.2" value="P802.1CBdb"/>
-        <format type="PDF" target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf"/>
+        <seriesInfo name="IEEE P802.1CBdb /D1.0" value="P802.1CBdb"/>
+        <format type="PDF" target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf"/>
       </reference>
 
       <reference anchor="IEEEP8021CBcv"
-                 target="http://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-3.pdf">
+                 target="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf">
         <front>
           <title>FRER YANG Data Model and Management Information Base Module</title>
           <author initials="S." surname="Kehrer" fullname="Stephan Kehrer">
             <organization>IEEE 802.1</organization>
           </author>
-          <date month="May" year="2020"/>
+          <date month="August" year="2020"/>
         </front>
-        <seriesInfo name="IEEE P802.1CBcv /D0.3" value="P802.1CBcv"/>
-        <format type="PDF" target="http://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-3.pdf"/>
+        <seriesInfo name="IEEE P802.1CBcv /D0.4" value="P802.1CBcv"/>
+        <format type="PDF" target="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf"/>
       </reference>
     </references>
 

--- a/ip-over-tsn/draft-ietf-detnet-ip-over-tsn.xml
+++ b/ip-over-tsn/draft-ietf-detnet-ip-over-tsn.xml
@@ -10,7 +10,7 @@
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
 <rfc category="info"
-     docName="draft-ietf-detnet-ip-over-tsn-04"
+     docName="draft-ietf-detnet-ip-over-tsn-05"
      ipr="trust200902"
      submissionType="IETF">
   <front>

--- a/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.html
+++ b/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.html
@@ -1,0 +1,852 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+
+  <title>DetNet Data Plane: MPLS over IEEE 802.1 Time Sensitive Networking (TSN)</title>
+
+  <style type="text/css" title="Xml2Rfc (sans serif)">
+  /*<![CDATA[*/
+	  a {
+	  text-decoration: none;
+	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
+	  a.smpl {
+	  color: black;
+	  }
+	  a:hover {
+	  text-decoration: underline;
+	  }
+	  a:active {
+	  text-decoration: underline;
+	  }
+	  address {
+	  margin-top: 1em;
+	  margin-left: 2em;
+	  font-style: normal;
+	  }
+	  body {
+	  color: black;
+	  font-family: verdana, helvetica, arial, sans-serif;
+	  font-size: 10pt;
+	  max-width: 55em;
+	  
+	  }
+	  cite {
+	  font-style: normal;
+	  }
+	  dd {
+	  margin-right: 2em;
+	  }
+	  dl {
+	  margin-left: 2em;
+	  }
+	
+	  ul.empty {
+	  list-style-type: none;
+	  }
+	  ul.empty li {
+	  margin-top: .5em;
+	  }
+	  dl p {
+	  margin-left: 0em;
+	  }
+	  dt {
+	  margin-top: .5em;
+	  }
+	  h1 {
+	  font-size: 14pt;
+	  line-height: 21pt;
+	  page-break-after: avoid;
+	  }
+	  h1.np {
+	  page-break-before: always;
+	  }
+	  h1 a {
+	  color: #333333;
+	  }
+	  h2 {
+	  font-size: 12pt;
+	  line-height: 15pt;
+	  page-break-after: avoid;
+	  }
+	  h3, h4, h5, h6 {
+	  font-size: 10pt;
+	  page-break-after: avoid;
+	  }
+	  h2 a, h3 a, h4 a, h5 a, h6 a {
+	  color: black;
+	  }
+	  img {
+	  margin-left: 3em;
+	  }
+	  li {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol p {
+	  margin-left: 0em;
+	  }
+	  p {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  pre {
+	  margin-left: 3em;
+	  background-color: lightyellow;
+	  padding: .25em;
+	  }
+	  pre.text2 {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f0f0f0;
+	  width: 69em;
+	  }
+	  pre.inline {
+	  background-color: white;
+	  padding: 0em;
+	  }
+	  pre.text {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  width: 69em;
+	  }
+	  pre.drawing {
+	  border-style: solid;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  padding: 2em;
+	  }
+	  table {
+	  margin-left: 2em;
+	  }
+	  table.tt {
+	  vertical-align: top;
+	  }
+	  table.full {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.headers {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.tt td {
+	  vertical-align: top;
+	  }
+	  table.full td {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.tt th {
+	  vertical-align: top;
+	  }
+	  table.full th {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.headers th {
+	  border-style: none none inset none;
+	  border-width: 1px;
+	  }
+	  table.left {
+	  margin-right: auto;
+	  }
+	  table.right {
+	  margin-left: auto;
+	  }
+	  table.center {
+	  margin-left: auto;
+	  margin-right: auto;
+	  }
+	  caption {
+	  caption-side: bottom;
+	  font-weight: bold;
+	  font-size: 9pt;
+	  margin-top: .5em;
+	  }
+	
+	  table.header {
+	  border-spacing: 1px;
+	  width: 95%;
+	  font-size: 10pt;
+	  color: white;
+	  }
+	  td.top {
+	  vertical-align: top;
+	  }
+	  td.topnowrap {
+	  vertical-align: top;
+	  white-space: nowrap; 
+	  }
+	  table.header td {
+	  background-color: gray;
+	  width: 50%;
+	  }
+	  table.header a {
+	  color: white;
+	  }
+	  td.reference {
+	  vertical-align: top;
+	  white-space: nowrap;
+	  padding-right: 1em;
+	  }
+	  thead {
+	  display:table-header-group;
+	  }
+	  ul.toc, ul.toc ul {
+	  list-style: none;
+	  margin-left: 1.5em;
+	  margin-right: 0em;
+	  padding-left: 0em;
+	  }
+	  ul.toc li {
+	  line-height: 150%;
+	  font-weight: bold;
+	  font-size: 10pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  ul.toc li li {
+	  line-height: normal;
+	  font-weight: normal;
+	  font-size: 9pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  li.excluded {
+	  font-size: 0pt;
+	  }
+	  ul p {
+	  margin-left: 0em;
+	  }
+	
+	  .comment {
+	  background-color: yellow;
+	  }
+	  .center {
+	  text-align: center;
+	  }
+	  .error {
+	  color: red;
+	  font-style: italic;
+	  font-weight: bold;
+	  }
+	  .figure {
+	  font-weight: bold;
+	  text-align: center;
+	  font-size: 9pt;
+	  }
+	  .filename {
+	  color: #333333;
+	  font-weight: bold;
+	  font-size: 12pt;
+	  line-height: 21pt;
+	  text-align: center;
+	  }
+	  .fn {
+	  font-weight: bold;
+	  }
+	  .hidden {
+	  display: none;
+	  }
+	  .left {
+	  text-align: left;
+	  }
+	  .right {
+	  text-align: right;
+	  }
+	  .title {
+	  color: #990000;
+	  font-size: 18pt;
+	  line-height: 18pt;
+	  font-weight: bold;
+	  text-align: center;
+	  margin-top: 36pt;
+	  }
+	  .vcardline {
+	  display: block;
+	  }
+	  .warning {
+	  font-size: 14pt;
+	  background-color: yellow;
+	  }
+	
+	
+	  @media print {
+	  .noprint {
+		display: none;
+	  }
+	
+	  a {
+		color: black;
+		text-decoration: none;
+	  }
+	
+	  table.header {
+		width: 90%;
+	  }
+	
+	  td.header {
+		width: 50%;
+		color: black;
+		background-color: white;
+		vertical-align: top;
+		font-size: 12pt;
+	  }
+	
+	  ul.toc a::after {
+		content: leader('.') target-counter(attr(href), page);
+	  }
+	
+	  ul.ind li li a {
+		content: target-counter(attr(href), page);
+	  }
+	
+	  .print2col {
+		column-count: 2;
+		-moz-column-count: 2;
+		column-fill: auto;
+	  }
+	  }
+	
+	  @page {
+	  @top-left {
+		   content: "Internet-Draft"; 
+	  } 
+	  @top-right {
+		   content: "December 2010"; 
+	  } 
+	  @top-center {
+		   content: "Abbreviated Title";
+	  } 
+	  @bottom-left {
+		   content: "Doe"; 
+	  } 
+	  @bottom-center {
+		   content: "Expires June 2011"; 
+	  } 
+	  @bottom-right {
+		   content: "[Page " counter(page) "]"; 
+	  } 
+	  }
+	
+	  @page:first { 
+		@top-left {
+		  content: normal;
+		}
+		@top-right {
+		  content: normal;
+		}
+		@top-center {
+		  content: normal;
+		}
+	  }
+  /*]]>*/
+  </style>
+
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.2" rel="Chapter" title="2 Terminology">
+<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Terms Used in This Document">
+<link href="#rfc.section.2.2" rel="Chapter" title="2.2 Abbreviations">
+<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Requirements Language">
+<link href="#rfc.section.3" rel="Chapter" title="3 DetNet MPLS Data Plane Overview">
+<link href="#rfc.section.4" rel="Chapter" title="4 DetNet MPLS Operation Over IEEE 802.1 TSN Sub-Networks">
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 Functions for DetNet Flow to TSN Stream Mapping">
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 TSN requirements of MPLS DetNet nodes">
+<link href="#rfc.section.4.3" rel="Chapter" title="4.3 Service protection within the TSN sub-network">
+<link href="#rfc.section.4.4" rel="Chapter" title="4.4 Aggregation during DetNet flow to TSN Stream mapping">
+<link href="#rfc.section.5" rel="Chapter" title="5 Management and Control Implications">
+<link href="#rfc.section.6" rel="Chapter" title="6 Security Considerations">
+<link href="#rfc.section.7" rel="Chapter" title="7 IANA Considerations">
+<link href="#rfc.section.8" rel="Chapter" title="8 Acknowledgements">
+<link href="#rfc.references" rel="Chapter" title="9 References">
+<link href="#rfc.references.1" rel="Chapter" title="9.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="9.2 Informative References">
+<link href="#rfc.authors" rel="Chapter">
+
+
+  <meta name="generator" content="xml2rfc version 2.22.3 - https://tools.ietf.org/tools/xml2rfc" />
+  <link rel="schema.dct" href="http://purl.org/dc/terms/" />
+
+  <meta name="dct.creator" content="Varga, B., Ed., Farkas, J., Malis, A., and S. Bryant" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-detnet-mpls-over-tsn-04" />
+  <meta name="dct.issued" scheme="ISO8601" content="2020-03" />
+  <meta name="dct.abstract" content="This document specifies the Deterministic Networking MPLS data plane when operating over a TSN sub-network. This document does not define new procedures or processes.  Whenever this document makes requirements statements or recommendations, these are taken from normative text in the referenced RFCs.  " />
+  <meta name="description" content="This document specifies the Deterministic Networking MPLS data plane when operating over a TSN sub-network. This document does not define new procedures or processes.  Whenever this document makes requirements statements or recommendations, these are taken from normative text in the referenced RFCs.  " />
+
+</head>
+
+<body>
+
+  <table class="header">
+    <tbody>
+    
+    	<tr>
+<td class="left">DetNet</td>
+<td class="right">B. Varga, Ed.</td>
+</tr>
+<tr>
+<td class="left">Internet-Draft</td>
+<td class="right">J. Farkas</td>
+</tr>
+<tr>
+<td class="left">Intended status: Informational</td>
+<td class="right">Ericsson</td>
+</tr>
+<tr>
+<td class="left">Expires: May 7, 2021</td>
+<td class="right">A. Malis</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">Malis Consulting</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">S. Bryant</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">Futurewei Technologies</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">November 3, 2020</td>
+</tr>
+
+    	
+    </tbody>
+  </table>
+
+  <p class="title">DetNet Data Plane: MPLS over IEEE 802.1 Time Sensitive Networking (TSN)<br />
+  <span class="filename">draft-ietf-detnet-mpls-over-tsn-04</span></p>
+  
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+<p>This document specifies the Deterministic Networking MPLS data plane when operating over a TSN sub-network. This document does not define new procedures or processes.  Whenever this document makes requirements statements or recommendations, these are taken from normative text in the referenced RFCs.  </p>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
+<p>This Internet-Draft will expire on May 7, 2021.</p>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
+<p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+
+  
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
+  <ul class="toc">
+
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<li>2.   <a href="#rfc.section.2">Terminology</a>
+</li>
+<ul><li>2.1.   <a href="#rfc.section.2.1">Terms Used in This Document</a>
+</li>
+<li>2.2.   <a href="#rfc.section.2.2">Abbreviations</a>
+</li>
+<li>2.3.   <a href="#rfc.section.2.3">Requirements Language</a>
+</li>
+</ul><li>3.   <a href="#rfc.section.3">DetNet MPLS Data Plane Overview</a>
+</li>
+<li>4.   <a href="#rfc.section.4">DetNet MPLS Operation Over IEEE 802.1 TSN Sub-Networks</a>
+</li>
+<ul><li>4.1.   <a href="#rfc.section.4.1">Functions for DetNet Flow to TSN Stream Mapping</a>
+</li>
+<li>4.2.   <a href="#rfc.section.4.2">TSN requirements of MPLS DetNet nodes</a>
+</li>
+<li>4.3.   <a href="#rfc.section.4.3">Service protection within the TSN sub-network</a>
+</li>
+<li>4.4.   <a href="#rfc.section.4.4">Aggregation during DetNet flow to TSN Stream mapping</a>
+</li>
+</ul><li>5.   <a href="#rfc.section.5">Management and Control Implications</a>
+</li>
+<li>6.   <a href="#rfc.section.6">Security Considerations</a>
+</li>
+<li>7.   <a href="#rfc.section.7">IANA Considerations</a>
+</li>
+<li>8.   <a href="#rfc.section.8">Acknowledgements</a>
+</li>
+<li>9.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>9.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>9.2.   <a href="#rfc.references.2">Informative References</a>
+</li>
+</ul><li><a href="#rfc.authors">Authors' Addresses</a>
+</li>
+
+
+  </ul>
+
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> <a href="#sec_intro" id="sec_intro">Introduction</a>
+</h1>
+<p id="rfc.section.1.p.1">Deterministic Networking (DetNet) is a service that can be offered by a network to DetNet flows.  DetNet provides these flows with a low packet loss rates and assured maximum end-to-end delivery latency.  General background and concepts of DetNet can be found in <a href="#RFC8655" class="xref">[RFC8655]</a>.  </p>
+<p id="rfc.section.1.p.2">The DetNet Architecture decomposes the DetNet related data plane functions into two sub-layers: a service sub-layer and a forwarding sub-layer.  The service sub-layer is used to provide DetNet service protection and reordering. The forwarding sub-layer is used to provides congestion protection (low loss, assured latency, and limited reordering) leveraging MPLS Traffic Engineering mechanisms.  </p>
+<p><a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a> specifies the DetNet data plane operation for MPLS-based Packet Switched Network (PSN).  MPLS encapsulated DetNet flows can be carried over network technologies that can provide the DetNet required level of service. This document focuses on the scenario where MPLS (DetNet) nodes are interconnected by a IEEE 802.1 TSN sub-network.  </p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> Terminology</h1>
+<h1 id="rfc.section.2.1">
+<a href="#rfc.section.2.1">2.1.</a> Terms Used in This Document</h1>
+<p id="rfc.section.2.1.p.1">This document uses the terminology established in the DetNet architecture <a href="#RFC8655" class="xref">[RFC8655]</a> and <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a>, and the reader is assumed to be familiar with that document and its terminology.  </p>
+<h1 id="rfc.section.2.2">
+<a href="#rfc.section.2.2">2.2.</a> Abbreviations</h1>
+<p id="rfc.section.2.2.p.1">The following abbreviations are used in this document: </p>
+
+<dl>
+<dt>CW</dt>
+<dd style="margin-left: 14">Control Word.</dd>
+<dt>DetNet</dt>
+<dd style="margin-left: 14">Deterministic Networking.</dd>
+<dt>DF</dt>
+<dd style="margin-left: 14">DetNet Flow.</dd>
+<dt>FRER</dt>
+<dd style="margin-left: 14">Frame Replication and Elimination for Redundancy (TSN function).</dd>
+<dt>L2</dt>
+<dd style="margin-left: 14">Layer 2.</dd>
+<dt>L3</dt>
+<dd style="margin-left: 14">Layer 3.</dd>
+<dt>LSR</dt>
+<dd style="margin-left: 14">Label Switching Router.</dd>
+<dt>MPLS</dt>
+<dd style="margin-left: 14">Multiprotocol Label Switching.</dd>
+<dt>PE</dt>
+<dd style="margin-left: 14">Provider Edge.</dd>
+<dt>PREOF</dt>
+<dd style="margin-left: 14">Packet Replication, Elimination and Ordering Functions.</dd>
+<dt>PSN</dt>
+<dd style="margin-left: 14">Packet Switched Network.</dd>
+<dt>PW</dt>
+<dd style="margin-left: 14">PseudoWire.</dd>
+<dt>S-PE</dt>
+<dd style="margin-left: 14">Switching Provider Edge.</dd>
+<dt>T-PE</dt>
+<dd style="margin-left: 14">Terminating Provider Edge.</dd>
+<dt>TSN</dt>
+<dd style="margin-left: 14">Time-Sensitive Network.</dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.section.2.3">
+<a href="#rfc.section.2.3">2.3.</a> Requirements Language</h1>
+<p id="rfc.section.2.3.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <a href="#RFC2119" class="xref">[RFC2119]</a> <a href="#RFC8174" class="xref">[RFC8174]</a> when, and only when, they appear in all capitals, as shown here.  </p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> <a href="#sec_dt_dp" id="sec_dt_dp">DetNet MPLS Data Plane Overview</a>
+</h1>
+<p id="rfc.section.3.p.1">The basic approach defined in <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a> supports the DetNet service sub-layer based on existing pseudowire (PW) encapsulations and mechanisms, and supports the DetNet forwarding sub-layer based on existing MPLS Traffic Engineering encapsulations and mechanisms.  </p>
+<p id="rfc.section.3.p.2">A node operating on a DetNet flow in the Detnet service sub-layer, i.e.  a node processing a DetNet packet which has the S-Label as top of stack uses the local context associated with that S-Label, for example a received F-Label, to determine what local DetNet operation(s) are applied to that packet. An S-Label may be unique when taken from the platform label space <a href="#RFC3031" class="xref">[RFC3031]</a>, which would enable correct DetNet flow identification regardless of which input interface or LSP the packet arrives on. The service sub-layer functions (i.e., PREOF) use a DetNet control word (d-CW).  </p>
+<p id="rfc.section.3.p.3">The DetNet MPLS data plane builds on MPLS Traffic Engineering encapsulations and mechanisms to provide a forwarding sub-layer that is responsible for providing resource allocation and explicit routes.  The forwarding sub-layer is supported by one or more forwarding labels (F-Labels).  </p>
+<p id="rfc.section.3.p.4">DetNet edge/relay nodes are DetNet service sub-layer aware, understand the particular needs of DetNet flows and provide both DetNet service and forwarding sub-layer functions.  They add, remove and process d-CWs, S-Labels and F-labels as needed.  MPLS DetNet nodes and transit nodes include DetNet forwarding sub-layer functions, support for notably explicit routes, and resources allocation to eliminate (or reduce) congestion loss and jitter. Unlike other DetNet node types, transit nodes provide no service sub-layer processing.  </p>
+<p id="rfc.section.3.p.5">MPLS (DetNet) nodes and transit nodes interconnected by a TSN sub-network are the primary focus of this document.  The mapping of DetNet MPLS flows to TSN streams and TSN protection mechanisms are covered in <a href="#mpls-over-tsn" class="xref">Section 4</a>.  </p>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> <a href="#mpls-over-tsn" id="mpls-over-tsn">DetNet MPLS Operation Over IEEE 802.1 TSN Sub-Networks</a>
+</h1>
+<p id="rfc.section.4.p.1">The DetNet WG collaborates with IEEE 802.1 TSN in order to define a common architecture for both Layer 2 and Layer 3, what maintains consistency across diverse networks. Both DetNet MPLS and TSN use the same techniques to provide their deterministic service: <a href="#RFC8655" class="xref">[RFC8655]</a> a sub-network provides from MPLS perspective a single hop connection between MPLS (DetNet) nodes.  Functions used for resource allocation and explicit routes are treated as domain internal functions and does not require function interworking across the DetNet MPLS network and the TSN sub-network.  </p>
+
+<ul>
+<li>Service protection.  </li>
+<li>Resource allocation.  </li>
+<li>Explicit routes.  </li>
+</ul>
+
+<p> As described in the DetNet architecture </p>
+<p id="rfc.section.4.p.2">In case of the service protection function due to the similarities of the DetNet PREOF and TSN FRER functions some level of interworking is possible. However, such interworking is out-of-scope in this document and left for further study.  </p>
+<p><a href="#fig_mpls_detnet_to_tsn" class="xref">Figure 1</a> illustrates a scenario, where two MPLS (DetNet) nodes are interconnected by a TSN sub-network. Node-1 is single homed and Node-2 is dual-homed to the TSN sub-network.  </p>
+<div id="rfc.figure.1"></div>
+<div id="fig_mpls_detnet_to_tsn"></div>
+<pre>
+   MPLS (DetNet)                 MPLS (DetNet)
+      Node-1                        Node-2
+
+   +----------+                  +----------+
+&lt;--| Service* |-- DetNet flow ---| Service* |--&gt;
+   +----------+                  +----------+
+   |Forwarding|                  |Forwarding|
+   +--------.-+    &lt;-TSN Str-&gt;   +-.-----.--+
+             \      ,-------.     /     /
+              +----[ TSN-Sub ]---+     /
+                   [ Network ]--------+
+                    `-------'
+&lt;---------------- DetNet MPLS ---------------&gt;
+
+Note: * no service sub-layer required for transit nodes
+</pre>
+<p class="figure">Figure 1: DetNet Enabled MPLS Network Over a TSN Sub-Network</p>
+<p id="rfc.section.4.p.4">The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1 Working Group have defined (and are defining) a number of amendments to <a href="#IEEE8021Q" class="xref">IEEE 802.1Q</a> that provide zero congestion loss and bounded latency in bridged networks. Furthermore <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> defines frame replication and elimination functions for reliability that should prove both compatible with and useful to, DetNet networks. All these functions have to identify flows those require TSN treatment.  </p>
+<p id="rfc.section.4.p.5">TSN capabilities of the TSN sub-network are made available for MPLS (DetNet) flows via the protocol interworking function defined in Annex C.5 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a>. For example, applied on the TSN edge port it can convert an ingress unicast MPLS (DetNet) flow to use a specific Layer-2 multicast destination MAC address and a VLAN, in order to direct the packet through a specific path inside the bridged network.  A similar interworking function pair at the other end of the TSN sub-network would restore the packet to its original Layer-2 destination MAC address and VLAN.  </p>
+<p id="rfc.section.4.p.6">Placement of TSN functions depends on the TSN capabilities of nodes. MPLS (DetNet) Nodes may or may not support TSN functions. For a given TSN Stream (i.e., DetNet flow) an MPLS (DetNet) node is treated as a Talker or a Listener inside the TSN sub-network.  </p>
+<h1 id="rfc.section.4.1">
+<a href="#rfc.section.4.1">4.1.</a> Functions for DetNet Flow to TSN Stream Mapping</h1>
+<p id="rfc.section.4.1.p.1">Mapping of a DetNet MPLS flow to a TSN Stream is provided via the combination of a passive and an active stream identification function that operate at the frame level. The passive stream identification function is used to catch the MPLS label(s) of a DetNet MPLS flow and the active stream identification function is used to modify the Ethernet header according to the ID of the mapped TSN Stream.  </p>
+<p id="rfc.section.4.1.p.2">Clause 6.8 of <a href="#IEEEP8021CBdb" class="xref">IEEE P802.1CBdb</a> defines a Mask-and-Match Stream identification function that can be used as a passive function for MPLS DetNet flows.  </p>
+<p id="rfc.section.4.1.p.3">Clause 6.6 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> defines an Active Destination MAC and VLAN Stream identification function, what can replace some Ethernet header fields namely (1) the destination MAC-address, (2) the VLAN-ID and (3) priority parameters with alternate values. Replacement is provided for the frame passed down the stack from the upper layers or up the stack from the lower layers.  </p>
+<p id="rfc.section.4.1.p.4">Active Destination MAC and VLAN Stream identification can be used within a Talker to set flow identity or a Listener to recover the original addressing information. It can be used also in a TSN bridge that is providing translation as a proxy service for an End System.  </p>
+<h1 id="rfc.section.4.2">
+<a href="#rfc.section.4.2">4.2.</a> TSN requirements of MPLS DetNet nodes</h1>
+<p id="rfc.section.4.2.p.1">This section covers required behavior of a TSN-aware MPLS (DetNet) node using a TSN sub-network. The implementation of TSN packet processing functions must be compliant with the relevant IEEE 802.1 standards.  </p>
+<p id="rfc.section.4.2.p.2">From the TSN sub-network perspective MPLS (DetNet) nodes are treated as Talker or Listener, that may be (1) TSN-unaware or (2) TSN-aware.  </p>
+<p id="rfc.section.4.2.p.3">In cases of TSN-unaware MPLS DetNet nodes the TSN relay nodes within the TSN sub-network must modify the Ethernet encapsulation of the DetNet MPLS flow (e.g., MAC translation, VLAN-ID setting, Sequence number addition, etc.) to allow proper TSN specific handling inside the sub-network.  There are no requirements defined for TSN-unaware MPLS DetNet nodes in this document.  </p>
+<p id="rfc.section.4.2.p.4">MPLS (DetNet) nodes being TSN-aware can be treated as a combination of a TSN-unaware Talker/Listener and a TSN-Relay, as shown in <a href="#fig_mpls_with_tsn" class="xref">Figure 2</a>.  In such cases the MPLS (DetNet) node must provide the TSN sub-network specific Ethernet encapsulation over the link(s) towards the sub-network.  </p>
+<div id="rfc.figure.2"></div>
+<div id="fig_mpls_with_tsn"></div>
+<pre>
+              MPLS (DetNet)
+                  Node
+   &lt;----------------------------------&gt;
+
+   +----------+
+&lt;--| Service* |-- DetNet flow ------------------
+   +----------+
+   |Forwarding|
+   +----------+    +---------------+
+   |    L2    |    | L2 Relay with |&lt;--- TSN ---
+   |          |    | TSN function  |    Stream
+   +-----.----+    +--.------.---.-+
+          \__________/        \   \______
+                               \_________
+    TSN-unaware
+     Talker /          TSN-Bridge
+     Listener             Relay
+                                       &lt;----- TSN Sub-network -----
+   &lt;------- TSN-aware Tlk/Lstn -------&gt;
+
+Note: * no service sub-layer required for transit nodes
+</pre>
+<p class="figure">Figure 2: MPLS (DetNet) Node with TSN Functions</p>
+<p id="rfc.section.4.2.p.5">A TSN-aware MPLS (DetNet) node impementations must support the Stream Identification TSN component for recognizing flows.  </p>
+<p id="rfc.section.4.2.p.6">A Stream identification component must be able to instantiate the following functions (1) Active Destination MAC and VLAN Stream identification function, (2) Mask-and-Match Stream identification function and (3) the related managed objects in Clause 9 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> and <a href="#IEEEP8021CBdb" class="xref">IEEE P802.1CBdb</a>.  </p>
+<p id="rfc.section.4.2.p.7">A TSN-aware MPLS (DetNet) node implementations must support the Sequencing function and the Sequence encode/decode function as defined in  Clause 7.4 and 7.6 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> if FRER is used inside the TSN sub-network.  </p>
+<p id="rfc.section.4.2.p.8">The Sequence encode/decode function must support the Redundancy tag (R-TAG) format as per Clause 7.8 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a>.  </p>
+<p id="rfc.section.4.2.p.9">A TSN-aware MPLS (DetNet) node implementations must support the Stream splitting function and the Individual recovery function as defined in Clause 7.7 and 7.5 of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> when the node is a replication or elimination point for FRER.  </p>
+<h1 id="rfc.section.4.3">
+<a href="#rfc.section.4.3">4.3.</a> Service protection within the TSN sub-network</h1>
+<p id="rfc.section.4.3.p.1">TSN Streams supporting DetNet flows may use Frame Replication and Elimination for Redundancy (FRER) as defined in Clause 8. of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> based on the loss service requirements of the TSN Stream, which is derived from the DetNet service requirements of the DetNet mapped flow.  The specific operation of FRER is not modified by the use of DetNet and follows <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a>.  </p>
+<p id="rfc.section.4.3.p.2">FRER function and the provided service recovery is available only within the TSN sub-network as the TSN Stream-ID and the TSN sequence number are not valid outside the sub-network.  An MPLS (DetNet) node represents a L3 border and as such it terminates all related information elements encoded in the L2 frames.  </p>
+<p id="rfc.section.4.3.p.3">As the Stream-ID and the TSN sequence number are paired with the similar MPLS flow parameters, FRER can be combined with PREOF functions. Such service protection interworking scenarios may require to move sequence number fields among TSN (L2) and PW (MPLS) encapsulations and they are left for further study.  </p>
+<h1 id="rfc.section.4.4">
+<a href="#rfc.section.4.4">4.4.</a> Aggregation during DetNet flow to TSN Stream mapping</h1>
+<p id="rfc.section.4.4.p.1">Implementations of this document shall use management and control information to map a DetNet flow to a TSN Stream. N:1 mapping (aggregating DetNet flows in a single TSN Stream) shall be supported. The management or control function that provisions flow mapping shall ensure that adequate resources are allocated and configured to provide proper service requirements of the mapped flows.  </p>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> Management and Control Implications</h1>
+<p id="rfc.section.5.p.1">DetNet flow and TSN Stream mapping related information are required only for TSN-aware MPLS (DetNet) nodes. From the Data Plane perspective there is no practical difference based on the origin of flow mapping related information (management plane or control plane).  </p>
+<p id="rfc.section.5.p.2">The following summarizes the set of information that is needed to configure DetNet MPLS over TSN: </p>
+
+<ul>
+<li>DetNet MPLS related configuration information according to the DetNet role of the DetNet MPLS node, as per <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a>. </li>
+<li>TSN related configuration information according to the TSN role of the DetNet MPLS node, as per <a href="#IEEE8021Q" class="xref">[IEEE8021Q]</a>, <a href="#IEEE8021CB" class="xref">[IEEE8021CB]</a> and <a href="#IEEEP8021CBdb" class="xref">[IEEEP8021CBdb]</a>. </li>
+<li>Mapping between DetNet MPLS flow(s) (label information: A-labels, S-labels and F-labels as defined in <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a>) and TSN Stream(s) (as stream identification information defined in <a href="#IEEEP8021CBdb" class="xref">[IEEEP8021CBdb]</a>).  Note, that managed objects for TSN Stream identification can be found in <a href="#IEEEP8021CBcv" class="xref">[IEEEP8021CBcv]</a>.  </li>
+</ul>
+
+<p> This information must be provisioned per DetNet flow.  </p>
+<p id="rfc.section.5.p.3">Mappings between DetNet and TSN management and control planes are out of scope of the document. Some of the challanges are highligthed below.  </p>
+<p id="rfc.section.5.p.4">TSN-aware MPLS DetNet nodes are member of both the DetNet domain and the TSN sub-network.  Within the TSN sub-network the TSN-aware MPLS (DetNet) node has a TSN-aware Talker/Listener role, so TSN specific management and control plane functionalities must be implemented.  There are many similarities in the management plane techniques used in DetNet and TSN, but that is not the case for the control plane protocols. For example, RSVP-TE and MSRP behaves differently. Therefore management and control plane design is an important aspect of scenarios, where mapping between DetNet and TSN is required.  </p>
+<p id="rfc.section.5.p.5">In order to use a TSN sub-network between DetNet nodes, DetNet specific information must be converted to TSN sub-network specific ones. DetNet flow ID and flow related parameters/requirements must be converted to a TSN Stream ID and stream related parameters/requirements. Note that, as the TSN sub-network is just a portion of the end2end DetNet path (i.e., single hop from MPLS perspective), some parameters (e.g., delay) may differ significantly. Other parameters (like bandwidth) also may have to be tuned due to the L2 encapsulation used within the TSN sub-network.  </p>
+<p id="rfc.section.5.p.6">In some case it may be challenging to determine some TSN Stream related information. For example, on a TSN-aware MPLS (DetNet) node that acts as a Talker, it is quite obvious which DetNet node is the Listener of the mapped TSN stream (i.e., the MPLS Next-Hop). However it may be not trivial to locate the point/interface where that Listener is connected to the TSN sub-network. Such attributes may require interaction between control and management plane functions and between DetNet and TSN domains.  </p>
+<p id="rfc.section.5.p.7">Mapping between DetNet flow identifiers and TSN Stream identifiers, if not provided explicitly, can be done by a TSN-aware MPLS (DetNet) node locally based on information provided for configuration of the TSN Stream identification functions (Mask-and-match Stream identification and Active Stream identification function).  </p>
+<p id="rfc.section.5.p.8">Triggering the setup/modification of a TSN Stream in the TSN sub-network is an example where management and/or control plane interactions are required between the DetNet and TSN sub-network. TSN-unaware MPLS (DetNet) nodes make such a triggering even more complicated as they are fully unaware of the sub-network and run independently.  </p>
+<p id="rfc.section.5.p.9">Configuration of TSN specific functions (e.g., FRER) inside the TSN sub-network is a TSN domain specific decision and may not be visible in the DetNet domain. Service protection interworking scenarios are left for further study.  </p>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> Security Considerations</h1>
+<p id="rfc.section.6.p.1">Security considerations for DetNet are described in detail in <a href="#I-D.ietf-detnet-security" class="xref">[I-D.ietf-detnet-security]</a>. General security considerations are described in <a href="#RFC8655" class="xref">[RFC8655]</a>.  DetNet MPLS data plane specific considerations are summarized in <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a>.  This section considers exclusively security considerations which are specific to the DetNet MPLS over TSN sub-network scenario.  </p>
+<p id="rfc.section.6.p.2">The sub-network between DetNet nodes needs to be subject to appropriate confidentiality. Additionally, knowledge of what DetNet/TSN services are provided by a sub-network may supply information that can be used in a variety of security attacks. The ability to modify information exchanges between connected DetNet nodes may result in bogus operations. Therefore, it is important that the interface between DetNet nodes and TSN sub-network are subject to authorization, authentication, and encryption.  </p>
+<p id="rfc.section.6.p.3">The TSN sub-network operates at Layer-2 so various security mechanisms defined by IEEE can be used to secure the connection between the DetNet nodes (e.g., encryption may be provided using MACSec <a href="#IEEE802.1AE-2018" class="xref">[IEEE802.1AE-2018]</a>).  </p>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#iana" id="iana">IANA Considerations</a>
+</h1>
+<p id="rfc.section.7.p.1">This document makes no IANA requests.  </p>
+<h1 id="rfc.section.8">
+<a href="#rfc.section.8">8.</a> <a href="#acks" id="acks">Acknowledgements</a>
+</h1>
+<p id="rfc.section.8.p.1">The authors wish to thank Norman Finn, Lou Berger, Craig Gunther, Christophe Mangin and Jouni Korhonen for their various contributions to this work.  </p>
+<h1 id="rfc.references">
+<a href="#rfc.references">9.</a> References</h1>
+<h1 id="rfc.references.1">
+<a href="#rfc.references.1">9.1.</a> Normative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="I-D.ietf-detnet-mpls">[I-D.ietf-detnet-mpls]</b></td>
+<td class="top">
+<a>Varga, B.</a>, <a>Farkas, J.</a>, <a>Berger, L.</a>, <a>Malis, A.</a>, <a>Bryant, S.</a> and <a>J. Korhonen</a>, "<a href="https://tools.ietf.org/html/draft-ietf-detnet-mpls-13">DetNet Data Plane: MPLS</a>", Internet-Draft draft-ietf-detnet-mpls-13, October 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3031">[RFC3031]</b></td>
+<td class="top">
+<a>Rosen, E.</a>, <a>Viswanathan, A.</a> and <a>R. Callon</a>, "<a href="https://tools.ietf.org/html/rfc3031">Multiprotocol Label Switching Architecture</a>", RFC 3031, DOI 10.17487/RFC3031, January 2001.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8174">[RFC8174]</b></td>
+<td class="top">
+<a>Leiba, B.</a>, "<a href="https://tools.ietf.org/html/rfc8174">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a>", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.references.2">
+<a href="#rfc.references.2">9.2.</a> Informative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="I-D.ietf-detnet-ip">[I-D.ietf-detnet-ip]</b></td>
+<td class="top">
+<a>Varga, B.</a>, <a>Farkas, J.</a>, <a>Berger, L.</a>, <a>Fedyk, D.</a> and <a>S. Bryant</a>, "<a href="https://tools.ietf.org/html/draft-ietf-detnet-ip-07">DetNet Data Plane: IP</a>", Internet-Draft draft-ietf-detnet-ip-07, July 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-detnet-security">[I-D.ietf-detnet-security]</b></td>
+<td class="top">
+<a>Grossman, E.</a>, <a>Mizrahi, T.</a> and <a>A. Hacker</a>, "<a href="https://tools.ietf.org/html/draft-ietf-detnet-security-12">Deterministic Networking (DetNet) Security Considerations</a>", Internet-Draft draft-ietf-detnet-security-12, October 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEE802.1AE-2018">[IEEE802.1AE-2018]</b></td>
+<td class="top">
+<a>IEEE Standards Association</a>, "<a href="https://ieeexplore.ieee.org/document/8585421">IEEE Std 802.1AE-2018 MAC Security (MACsec)</a>", 2018.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEE8021CB">[IEEE8021CB]</b></td>
+<td class="top">
+<a>IEEE 802.1</a>, "<a href="http://standards.ieee.org/about/get/">Standard for Local and metropolitan area networks - Frame Replication and Elimination for Reliability (IEEE Std 802.1CB-2017)</a>", 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEE8021Q">[IEEE8021Q]</b></td>
+<td class="top">
+<a>IEEE 802.1</a>, "<a href="http://standards.ieee.org/about/get/">Standard for Local and metropolitan area networks--Bridges and Bridged Networks (IEEE Std 802.1Q-2018)</a>", 2018.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEEP8021CBcv">[IEEEP8021CBcv]</b></td>
+<td class="top">
+<a title="IEEE 802.1">Kehrer, S.</a>, "<a href="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf">FRER YANG Data Model and Management Information Base Module</a>", IEEE P802.1CBcv /D0.4 P802.1CBcv, August 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEEP8021CBdb">[IEEEP8021CBdb]</b></td>
+<td class="top">
+<a title="IEEE 802.1">Mangin, C.</a>, "<a href="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf">Extended Stream identification functions</a>", IEEE P802.1CBdb /D1.0 P802.1CBdb, September 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8655">[RFC8655]</b></td>
+<td class="top">
+<a>Finn, N.</a>, <a>Thubert, P.</a>, <a>Varga, B.</a> and <a>J. Farkas</a>, "<a href="https://tools.ietf.org/html/rfc8655">Deterministic Networking Architecture</a>", RFC 8655, DOI 10.17487/RFC8655, October 2019.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
+<div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Bal&#225;zs Varga</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Varga</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Ericsson</span>
+	<span class="adr">
+	  <span class="vcardline">Magyar Tudosok krt. 11.</span>
+
+	  <span class="vcardline">
+		<span class="locality">Budapest</span>,  
+		<span class="region"></span>
+		<span class="code">1117</span>
+	  </span>
+	  <span class="country-name vcardline">Hungary</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:balazs.a.varga@ericsson.com">balazs.a.varga@ericsson.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">J&#225;nos Farkas</span> 
+	  <span class="n hidden">
+		<span class="family-name">Farkas</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Ericsson</span>
+	<span class="adr">
+	  <span class="vcardline">Magyar Tudosok krt. 11.</span>
+
+	  <span class="vcardline">
+		<span class="locality">Budapest</span>,  
+		<span class="region"></span>
+		<span class="code">1117</span>
+	  </span>
+	  <span class="country-name vcardline">Hungary</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:janos.farkas@ericsson.com">janos.farkas@ericsson.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Andrew G. Malis</span> 
+	  <span class="n hidden">
+		<span class="family-name">Malis</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Malis Consulting</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:agmalis@gmail.com">agmalis@gmail.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Stewart Bryant</span> 
+	  <span class="n hidden">
+		<span class="family-name">Bryant</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Futurewei Technologies</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:stewart.bryant@gmail.com">stewart.bryant@gmail.com</a></span>
+
+  </address>
+</div>
+
+</body>
+</html>

--- a/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.html
+++ b/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.html
@@ -424,7 +424,7 @@
 <td class="right">Ericsson</td>
 </tr>
 <tr>
-<td class="left">Expires: May 7, 2021</td>
+<td class="left">Expires: May 6, 2021</td>
 <td class="right">A. Malis</td>
 </tr>
 <tr>
@@ -441,7 +441,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">November 3, 2020</td>
+<td class="right">November 2, 2020</td>
 </tr>
 
     	
@@ -457,7 +457,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on May 7, 2021.</p>
+<p>This Internet-Draft will expire on May 6, 2021.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>

--- a/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.txt
+++ b/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.txt
@@ -1,0 +1,728 @@
+
+
+
+
+DetNet                                                     B. Varga, Ed.
+Internet-Draft                                                 J. Farkas
+Intended status: Informational                                  Ericsson
+Expires: May 7, 2021                                            A. Malis
+                                                        Malis Consulting
+                                                               S. Bryant
+                                                  Futurewei Technologies
+                                                        November 3, 2020
+
+
+DetNet Data Plane: MPLS over IEEE 802.1 Time Sensitive Networking (TSN)
+                   draft-ietf-detnet-mpls-over-tsn-04
+
+Abstract
+
+   This document specifies the Deterministic Networking MPLS data plane
+   when operating over a TSN sub-network.  This document does not define
+   new procedures or processes.  Whenever this document makes
+   requirements statements or recommendations, these are taken from
+   normative text in the referenced RFCs.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on May 7, 2021.
+
+Copyright Notice
+
+   Copyright (c) 2020 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 1]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   3
+     2.1.  Terms Used in This Document . . . . . . . . . . . . . . .   3
+     2.2.  Abbreviations . . . . . . . . . . . . . . . . . . . . . .   3
+     2.3.  Requirements Language . . . . . . . . . . . . . . . . . .   3
+   3.  DetNet MPLS Data Plane Overview . . . . . . . . . . . . . . .   4
+   4.  DetNet MPLS Operation Over IEEE 802.1 TSN Sub-Networks  . . .   4
+     4.1.  Functions for DetNet Flow to TSN Stream Mapping . . . . .   6
+     4.2.  TSN requirements of MPLS DetNet nodes . . . . . . . . . .   6
+     4.3.  Service protection within the TSN sub-network . . . . . .   8
+     4.4.  Aggregation during DetNet flow to TSN Stream mapping  . .   8
+   5.  Management and Control Implications . . . . . . . . . . . . .   8
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  11
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  11
+   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  11
+     9.1.  Normative References  . . . . . . . . . . . . . . . . . .  11
+     9.2.  Informative References  . . . . . . . . . . . . . . . . .  11
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  12
+
+1.  Introduction
+
+   Deterministic Networking (DetNet) is a service that can be offered by
+   a network to DetNet flows.  DetNet provides these flows with a low
+   packet loss rates and assured maximum end-to-end delivery latency.
+   General background and concepts of DetNet can be found in [RFC8655].
+
+   The DetNet Architecture decomposes the DetNet related data plane
+   functions into two sub-layers: a service sub-layer and a forwarding
+   sub-layer.  The service sub-layer is used to provide DetNet service
+   protection and reordering.  The forwarding sub-layer is used to
+   provides congestion protection (low loss, assured latency, and
+   limited reordering) leveraging MPLS Traffic Engineering mechanisms.
+
+   [I-D.ietf-detnet-mpls] specifies the DetNet data plane operation for
+   MPLS-based Packet Switched Network (PSN).  MPLS encapsulated DetNet
+   flows can be carried over network technologies that can provide the
+   DetNet required level of service.  This document focuses on the
+   scenario where MPLS (DetNet) nodes are interconnected by a IEEE 802.1
+   TSN sub-network.
+
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 2]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+2.  Terminology
+
+2.1.  Terms Used in This Document
+
+   This document uses the terminology established in the DetNet
+   architecture [RFC8655] and [I-D.ietf-detnet-mpls], and the reader is
+   assumed to be familiar with that document and its terminology.
+
+2.2.  Abbreviations
+
+   The following abbreviations are used in this document:
+
+   CW            Control Word.
+
+   DetNet        Deterministic Networking.
+
+   DF            DetNet Flow.
+
+   FRER          Frame Replication and Elimination for Redundancy (TSN
+                 function).
+
+   L2            Layer 2.
+
+   L3            Layer 3.
+
+   LSR           Label Switching Router.
+
+   MPLS          Multiprotocol Label Switching.
+
+   PE            Provider Edge.
+
+   PREOF         Packet Replication, Elimination and Ordering Functions.
+
+   PSN           Packet Switched Network.
+
+   PW            PseudoWire.
+
+   S-PE          Switching Provider Edge.
+
+   T-PE          Terminating Provider Edge.
+
+   TSN           Time-Sensitive Network.
+
+2.3.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 3]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+3.  DetNet MPLS Data Plane Overview
+
+   The basic approach defined in [I-D.ietf-detnet-mpls] supports the
+   DetNet service sub-layer based on existing pseudowire (PW)
+   encapsulations and mechanisms, and supports the DetNet forwarding
+   sub-layer based on existing MPLS Traffic Engineering encapsulations
+   and mechanisms.
+
+   A node operating on a DetNet flow in the Detnet service sub-layer,
+   i.e.  a node processing a DetNet packet which has the S-Label as top
+   of stack uses the local context associated with that S-Label, for
+   example a received F-Label, to determine what local DetNet
+   operation(s) are applied to that packet.  An S-Label may be unique
+   when taken from the platform label space [RFC3031], which would
+   enable correct DetNet flow identification regardless of which input
+   interface or LSP the packet arrives on.  The service sub-layer
+   functions (i.e., PREOF) use a DetNet control word (d-CW).
+
+   The DetNet MPLS data plane builds on MPLS Traffic Engineering
+   encapsulations and mechanisms to provide a forwarding sub-layer that
+   is responsible for providing resource allocation and explicit routes.
+   The forwarding sub-layer is supported by one or more forwarding
+   labels (F-Labels).
+
+   DetNet edge/relay nodes are DetNet service sub-layer aware,
+   understand the particular needs of DetNet flows and provide both
+   DetNet service and forwarding sub-layer functions.  They add, remove
+   and process d-CWs, S-Labels and F-labels as needed.  MPLS DetNet
+   nodes and transit nodes include DetNet forwarding sub-layer
+   functions, support for notably explicit routes, and resources
+   allocation to eliminate (or reduce) congestion loss and jitter.
+   Unlike other DetNet node types, transit nodes provide no service sub-
+   layer processing.
+
+   MPLS (DetNet) nodes and transit nodes interconnected by a TSN sub-
+   network are the primary focus of this document.  The mapping of
+   DetNet MPLS flows to TSN streams and TSN protection mechanisms are
+   covered in Section 4.
+
+4.  DetNet MPLS Operation Over IEEE 802.1 TSN Sub-Networks
+
+   The DetNet WG collaborates with IEEE 802.1 TSN in order to define a
+   common architecture for both Layer 2 and Layer 3, what maintains
+   consistency across diverse networks.  Both DetNet MPLS and TSN use
+   the same techniques to provide their deterministic service:
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 4]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   o  Service protection.
+
+   o  Resource allocation.
+
+   o  Explicit routes.
+
+   As described in the DetNet architecture [RFC8655] a sub-network
+   provides from MPLS perspective a single hop connection between MPLS
+   (DetNet) nodes.  Functions used for resource allocation and explicit
+   routes are treated as domain internal functions and does not require
+   function interworking across the DetNet MPLS network and the TSN sub-
+   network.
+
+   In case of the service protection function due to the similarities of
+   the DetNet PREOF and TSN FRER functions some level of interworking is
+   possible.  However, such interworking is out-of-scope in this
+   document and left for further study.
+
+   Figure 1 illustrates a scenario, where two MPLS (DetNet) nodes are
+   interconnected by a TSN sub-network.  Node-1 is single homed and
+   Node-2 is dual-homed to the TSN sub-network.
+
+      MPLS (DetNet)                 MPLS (DetNet)
+         Node-1                        Node-2
+
+      +----------+                  +----------+
+   <--| Service* |-- DetNet flow ---| Service* |-->
+      +----------+                  +----------+
+      |Forwarding|                  |Forwarding|
+      +--------.-+    <-TSN Str->   +-.-----.--+
+                \      ,-------.     /     /
+                 +----[ TSN-Sub ]---+     /
+                      [ Network ]--------+
+                       `-------'
+   <---------------- DetNet MPLS --------------->
+
+   Note: * no service sub-layer required for transit nodes
+
+       Figure 1: DetNet Enabled MPLS Network Over a TSN Sub-Network
+
+   The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1
+   Working Group have defined (and are defining) a number of amendments
+   to IEEE 802.1Q [IEEE8021Q] that provide zero congestion loss and
+   bounded latency in bridged networks.  Furthermore IEEE 802.1CB
+   [IEEE8021CB] defines frame replication and elimination functions for
+   reliability that should prove both compatible with and useful to,
+   DetNet networks.  All these functions have to identify flows those
+   require TSN treatment.
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 5]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   TSN capabilities of the TSN sub-network are made available for MPLS
+   (DetNet) flows via the protocol interworking function defined in
+   Annex C.5 of IEEE 802.1CB [IEEE8021CB].  For example, applied on the
+   TSN edge port it can convert an ingress unicast MPLS (DetNet) flow to
+   use a specific Layer-2 multicast destination MAC address and a VLAN,
+   in order to direct the packet through a specific path inside the
+   bridged network.  A similar interworking function pair at the other
+   end of the TSN sub-network would restore the packet to its original
+   Layer-2 destination MAC address and VLAN.
+
+   Placement of TSN functions depends on the TSN capabilities of nodes.
+   MPLS (DetNet) Nodes may or may not support TSN functions.  For a
+   given TSN Stream (i.e., DetNet flow) an MPLS (DetNet) node is treated
+   as a Talker or a Listener inside the TSN sub-network.
+
+4.1.  Functions for DetNet Flow to TSN Stream Mapping
+
+   Mapping of a DetNet MPLS flow to a TSN Stream is provided via the
+   combination of a passive and an active stream identification function
+   that operate at the frame level.  The passive stream identification
+   function is used to catch the MPLS label(s) of a DetNet MPLS flow and
+   the active stream identification function is used to modify the
+   Ethernet header according to the ID of the mapped TSN Stream.
+
+   Clause 6.8 of IEEE P802.1CBdb [IEEEP8021CBdb] defines a Mask-and-
+   Match Stream identification function that can be used as a passive
+   function for MPLS DetNet flows.
+
+   Clause 6.6 of IEEE 802.1CB [IEEE8021CB] defines an Active Destination
+   MAC and VLAN Stream identification function, what can replace some
+   Ethernet header fields namely (1) the destination MAC-address, (2)
+   the VLAN-ID and (3) priority parameters with alternate values.
+   Replacement is provided for the frame passed down the stack from the
+   upper layers or up the stack from the lower layers.
+
+   Active Destination MAC and VLAN Stream identification can be used
+   within a Talker to set flow identity or a Listener to recover the
+   original addressing information.  It can be used also in a TSN bridge
+   that is providing translation as a proxy service for an End System.
+
+4.2.  TSN requirements of MPLS DetNet nodes
+
+   This section covers required behavior of a TSN-aware MPLS (DetNet)
+   node using a TSN sub-network.  The implementation of TSN packet
+   processing functions must be compliant with the relevant IEEE 802.1
+   standards.
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 6]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   From the TSN sub-network perspective MPLS (DetNet) nodes are treated
+   as Talker or Listener, that may be (1) TSN-unaware or (2) TSN-aware.
+
+   In cases of TSN-unaware MPLS DetNet nodes the TSN relay nodes within
+   the TSN sub-network must modify the Ethernet encapsulation of the
+   DetNet MPLS flow (e.g., MAC translation, VLAN-ID setting, Sequence
+   number addition, etc.) to allow proper TSN specific handling inside
+   the sub-network.  There are no requirements defined for TSN-unaware
+   MPLS DetNet nodes in this document.
+
+   MPLS (DetNet) nodes being TSN-aware can be treated as a combination
+   of a TSN-unaware Talker/Listener and a TSN-Relay, as shown in
+   Figure 2.  In such cases the MPLS (DetNet) node must provide the TSN
+   sub-network specific Ethernet encapsulation over the link(s) towards
+   the sub-network.
+
+                 MPLS (DetNet)
+                     Node
+      <---------------------------------->
+
+      +----------+
+   <--| Service* |-- DetNet flow ------------------
+      +----------+
+      |Forwarding|
+      +----------+    +---------------+
+      |    L2    |    | L2 Relay with |<--- TSN ---
+      |          |    | TSN function  |    Stream
+      +-----.----+    +--.------.---.-+
+             \__________/        \   \______
+                                  \_________
+       TSN-unaware
+        Talker /          TSN-Bridge
+        Listener             Relay
+                                          <----- TSN Sub-network -----
+      <------- TSN-aware Tlk/Lstn ------->
+
+   Note: * no service sub-layer required for transit nodes
+
+              Figure 2: MPLS (DetNet) Node with TSN Functions
+
+   A TSN-aware MPLS (DetNet) node impementations must support the Stream
+   Identification TSN component for recognizing flows.
+
+   A Stream identification component must be able to instantiate the
+   following functions (1) Active Destination MAC and VLAN Stream
+   identification function, (2) Mask-and-Match Stream identification
+   function and (3) the related managed objects in Clause 9 of IEEE
+   802.1CB [IEEE8021CB] and IEEE P802.1CBdb [IEEEP8021CBdb].
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 7]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   A TSN-aware MPLS (DetNet) node implementations must support the
+   Sequencing function and the Sequence encode/decode function as
+   defined in Clause 7.4 and 7.6 of IEEE 802.1CB [IEEE8021CB] if FRER is
+   used inside the TSN sub-network.
+
+   The Sequence encode/decode function must support the Redundancy tag
+   (R-TAG) format as per Clause 7.8 of IEEE 802.1CB [IEEE8021CB].
+
+   A TSN-aware MPLS (DetNet) node implementations must support the
+   Stream splitting function and the Individual recovery function as
+   defined in Clause 7.7 and 7.5 of IEEE 802.1CB [IEEE8021CB] when the
+   node is a replication or elimination point for FRER.
+
+4.3.  Service protection within the TSN sub-network
+
+   TSN Streams supporting DetNet flows may use Frame Replication and
+   Elimination for Redundancy (FRER) as defined in Clause 8. of IEEE
+   802.1CB [IEEE8021CB] based on the loss service requirements of the
+   TSN Stream, which is derived from the DetNet service requirements of
+   the DetNet mapped flow.  The specific operation of FRER is not
+   modified by the use of DetNet and follows IEEE 802.1CB [IEEE8021CB].
+
+   FRER function and the provided service recovery is available only
+   within the TSN sub-network as the TSN Stream-ID and the TSN sequence
+   number are not valid outside the sub-network.  An MPLS (DetNet) node
+   represents a L3 border and as such it terminates all related
+   information elements encoded in the L2 frames.
+
+   As the Stream-ID and the TSN sequence number are paired with the
+   similar MPLS flow parameters, FRER can be combined with PREOF
+   functions.  Such service protection interworking scenarios may
+   require to move sequence number fields among TSN (L2) and PW (MPLS)
+   encapsulations and they are left for further study.
+
+4.4.  Aggregation during DetNet flow to TSN Stream mapping
+
+   Implementations of this document shall use management and control
+   information to map a DetNet flow to a TSN Stream.  N:1 mapping
+   (aggregating DetNet flows in a single TSN Stream) shall be supported.
+   The management or control function that provisions flow mapping shall
+   ensure that adequate resources are allocated and configured to
+   provide proper service requirements of the mapped flows.
+
+5.  Management and Control Implications
+
+   DetNet flow and TSN Stream mapping related information are required
+   only for TSN-aware MPLS (DetNet) nodes.  From the Data Plane
+
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 8]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   perspective there is no practical difference based on the origin of
+   flow mapping related information (management plane or control plane).
+
+   The following summarizes the set of information that is needed to
+   configure DetNet MPLS over TSN:
+
+   o  DetNet MPLS related configuration information according to the
+      DetNet role of the DetNet MPLS node, as per
+      [I-D.ietf-detnet-mpls].
+
+   o  TSN related configuration information according to the TSN role of
+      the DetNet MPLS node, as per [IEEE8021Q], [IEEE8021CB] and
+      [IEEEP8021CBdb].
+
+   o  Mapping between DetNet MPLS flow(s) (label information: A-labels,
+      S-labels and F-labels as defined in [I-D.ietf-detnet-mpls]) and
+      TSN Stream(s) (as stream identification information defined in
+      [IEEEP8021CBdb]).  Note, that managed objects for TSN Stream
+      identification can be found in [IEEEP8021CBcv].
+
+   This information must be provisioned per DetNet flow.
+
+   Mappings between DetNet and TSN management and control planes are out
+   of scope of the document.  Some of the challanges are highligthed
+   below.
+
+   TSN-aware MPLS DetNet nodes are member of both the DetNet domain and
+   the TSN sub-network.  Within the TSN sub-network the TSN-aware MPLS
+   (DetNet) node has a TSN-aware Talker/Listener role, so TSN specific
+   management and control plane functionalities must be implemented.
+   There are many similarities in the management plane techniques used
+   in DetNet and TSN, but that is not the case for the control plane
+   protocols.  For example, RSVP-TE and MSRP behaves differently.
+   Therefore management and control plane design is an important aspect
+   of scenarios, where mapping between DetNet and TSN is required.
+
+   In order to use a TSN sub-network between DetNet nodes, DetNet
+   specific information must be converted to TSN sub-network specific
+   ones.  DetNet flow ID and flow related parameters/requirements must
+   be converted to a TSN Stream ID and stream related parameters/
+   requirements.  Note that, as the TSN sub-network is just a portion of
+   the end2end DetNet path (i.e., single hop from MPLS perspective),
+   some parameters (e.g., delay) may differ significantly.  Other
+   parameters (like bandwidth) also may have to be tuned due to the L2
+   encapsulation used within the TSN sub-network.
+
+   In some case it may be challenging to determine some TSN Stream
+   related information.  For example, on a TSN-aware MPLS (DetNet) node
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 9]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   that acts as a Talker, it is quite obvious which DetNet node is the
+   Listener of the mapped TSN stream (i.e., the MPLS Next-Hop).  However
+   it may be not trivial to locate the point/interface where that
+   Listener is connected to the TSN sub-network.  Such attributes may
+   require interaction between control and management plane functions
+   and between DetNet and TSN domains.
+
+   Mapping between DetNet flow identifiers and TSN Stream identifiers,
+   if not provided explicitly, can be done by a TSN-aware MPLS (DetNet)
+   node locally based on information provided for configuration of the
+   TSN Stream identification functions (Mask-and-match Stream
+   identification and Active Stream identification function).
+
+   Triggering the setup/modification of a TSN Stream in the TSN sub-
+   network is an example where management and/or control plane
+   interactions are required between the DetNet and TSN sub-network.
+   TSN-unaware MPLS (DetNet) nodes make such a triggering even more
+   complicated as they are fully unaware of the sub-network and run
+   independently.
+
+   Configuration of TSN specific functions (e.g., FRER) inside the TSN
+   sub-network is a TSN domain specific decision and may not be visible
+   in the DetNet domain.  Service protection interworking scenarios are
+   left for further study.
+
+6.  Security Considerations
+
+   Security considerations for DetNet are described in detail in
+   [I-D.ietf-detnet-security].  General security considerations are
+   described in [RFC8655].  DetNet MPLS data plane specific
+   considerations are summarized in [I-D.ietf-detnet-mpls].  This
+   section considers exclusively security considerations which are
+   specific to the DetNet MPLS over TSN sub-network scenario.
+
+   The sub-network between DetNet nodes needs to be subject to
+   appropriate confidentiality.  Additionally, knowledge of what DetNet/
+   TSN services are provided by a sub-network may supply information
+   that can be used in a variety of security attacks.  The ability to
+   modify information exchanges between connected DetNet nodes may
+   result in bogus operations.  Therefore, it is important that the
+   interface between DetNet nodes and TSN sub-network are subject to
+   authorization, authentication, and encryption.
+
+   The TSN sub-network operates at Layer-2 so various security
+   mechanisms defined by IEEE can be used to secure the connection
+   between the DetNet nodes (e.g., encryption may be provided using
+   MACSec [IEEE802.1AE-2018]).
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 10]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+7.  IANA Considerations
+
+   This document makes no IANA requests.
+
+8.  Acknowledgements
+
+   The authors wish to thank Norman Finn, Lou Berger, Craig Gunther,
+   Christophe Mangin and Jouni Korhonen for their various contributions
+   to this work.
+
+9.  References
+
+9.1.  Normative References
+
+   [I-D.ietf-detnet-mpls]
+              Varga, B., Farkas, J., Berger, L., Malis, A., Bryant, S.,
+              and J. Korhonen, "DetNet Data Plane: MPLS", draft-ietf-
+              detnet-mpls-13 (work in progress), October 2020.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3031]  Rosen, E., Viswanathan, A., and R. Callon, "Multiprotocol
+              Label Switching Architecture", RFC 3031,
+              DOI 10.17487/RFC3031, January 2001,
+              <https://www.rfc-editor.org/info/rfc3031>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+9.2.  Informative References
+
+   [I-D.ietf-detnet-ip]
+              Varga, B., Farkas, J., Berger, L., Fedyk, D., and S.
+              Bryant, "DetNet Data Plane: IP", draft-ietf-detnet-ip-07
+              (work in progress), July 2020.
+
+   [I-D.ietf-detnet-security]
+              Grossman, E., Mizrahi, T., and A. Hacker, "Deterministic
+              Networking (DetNet) Security Considerations", draft-ietf-
+              detnet-security-12 (work in progress), October 2020.
+
+
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 11]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   [IEEE802.1AE-2018]
+              IEEE Standards Association, "IEEE Std 802.1AE-2018 MAC
+              Security (MACsec)", 2018,
+              <https://ieeexplore.ieee.org/document/8585421>.
+
+   [IEEE8021CB]
+              IEEE 802.1, "Standard for Local and metropolitan area
+              networks - Frame Replication and Elimination for
+              Reliability (IEEE Std 802.1CB-2017)", 2017,
+              <http://standards.ieee.org/about/get/>.
+
+   [IEEE8021Q]
+              IEEE 802.1, "Standard for Local and metropolitan area
+              networks--Bridges and Bridged Networks (IEEE Std 802.1Q-
+              2018)", 2018, <http://standards.ieee.org/about/get/>.
+
+   [IEEEP8021CBcv]
+              Kehrer, S., "FRER YANG Data Model and Management
+              Information Base Module", IEEE P802.1CBcv
+              /D0.4 P802.1CBcv, August 2020,
+              <https://www.ieee802.org/1/files/private/cv-drafts/
+              d0/802-1CBcv-d0-4.pdf>.
+
+   [IEEEP8021CBdb]
+              Mangin, C., "Extended Stream identification functions",
+              IEEE P802.1CBdb /D1.0 P802.1CBdb, September 2020,
+              <http://www.ieee802.org/1/files/private/db-drafts/
+              d1/802-1CBdb-d1-0.pdf>.
+
+   [RFC8655]  Finn, N., Thubert, P., Varga, B., and J. Farkas,
+              "Deterministic Networking Architecture", RFC 8655,
+              DOI 10.17487/RFC8655, October 2019,
+              <https://www.rfc-editor.org/info/rfc8655>.
+
+Authors' Addresses
+
+   Balazs Varga (editor)
+   Ericsson
+   Magyar Tudosok krt. 11.
+   Budapest  1117
+   Hungary
+
+   Email: balazs.a.varga@ericsson.com
+
+
+
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 12]
+
+Internet-Draft            DetNet MPLS over TSN             November 2020
+
+
+   Janos Farkas
+   Ericsson
+   Magyar Tudosok krt. 11.
+   Budapest  1117
+   Hungary
+
+   Email: janos.farkas@ericsson.com
+
+
+   Andrew G. Malis
+   Malis Consulting
+
+   Email: agmalis@gmail.com
+
+
+   Stewart Bryant
+   Futurewei Technologies
+
+   Email: stewart.bryant@gmail.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 13]

--- a/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.txt
+++ b/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.txt
@@ -5,11 +5,11 @@
 DetNet                                                     B. Varga, Ed.
 Internet-Draft                                                 J. Farkas
 Intended status: Informational                                  Ericsson
-Expires: May 7, 2021                                            A. Malis
+Expires: May 6, 2021                                            A. Malis
                                                         Malis Consulting
                                                                S. Bryant
                                                   Futurewei Technologies
-                                                        November 3, 2020
+                                                        November 2, 2020
 
 
 DetNet Data Plane: MPLS over IEEE 802.1 Time Sensitive Networking (TSN)
@@ -38,7 +38,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 7, 2021.
+   This Internet-Draft will expire on May 6, 2021.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 1]
+Varga, et al.              Expires May 6, 2021                  [Page 1]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 2]
+Varga, et al.              Expires May 6, 2021                  [Page 2]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -165,7 +165,7 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 3]
+Varga, et al.              Expires May 6, 2021                  [Page 3]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -221,7 +221,7 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 4]
+Varga, et al.              Expires May 6, 2021                  [Page 4]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -277,7 +277,7 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 5]
+Varga, et al.              Expires May 6, 2021                  [Page 5]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -333,7 +333,7 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 6]
+Varga, et al.              Expires May 6, 2021                  [Page 6]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -389,7 +389,7 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 7]
+Varga, et al.              Expires May 6, 2021                  [Page 7]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -445,7 +445,7 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 8]
+Varga, et al.              Expires May 6, 2021                  [Page 8]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -501,7 +501,7 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 9]
+Varga, et al.              Expires May 6, 2021                  [Page 9]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -557,7 +557,7 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 10]
+Varga, et al.              Expires May 6, 2021                 [Page 10]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -613,7 +613,7 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 11]
+Varga, et al.              Expires May 6, 2021                 [Page 11]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -669,7 +669,7 @@ Authors' Addresses
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 12]
+Varga, et al.              Expires May 6, 2021                 [Page 12]
 
 Internet-Draft            DetNet MPLS over TSN             November 2020
 
@@ -725,4 +725,4 @@ Internet-Draft            DetNet MPLS over TSN             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 13]
+Varga, et al.              Expires May 6, 2021                 [Page 13]

--- a/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.xml
+++ b/mpls-over-tsn/IDs/draft-ietf-detnet-mpls-over-tsn-04.xml
@@ -1,0 +1,659 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+<!ENTITY rfc2119 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
+<!ENTITY rfc3031 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3031.xml">
+
+]>
+<?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
+<?rfc toc="yes"?>
+<?rfc symrefs="yes"?>
+<?rfc sortrefs="yes"?>
+<?rfc iprnotified="no"?>
+<?rfc strict="yes"?>
+<?rfc compact="yes"?>
+<?rfc subcompact="no"?>
+<rfc category="info"
+     docName="draft-ietf-detnet-mpls-over-tsn-04"
+         ipr="trust200902"
+         submissionType="IETF">
+  <front>
+    <title abbrev="DetNet MPLS over TSN">
+    DetNet Data Plane: MPLS over IEEE 802.1 Time Sensitive Networking (TSN)</title>
+
+  <author role="editor" fullname="Bal&aacute;zs Varga" initials="B." surname="Varga">
+	<organization>Ericsson</organization>
+	<address>
+	 <postal>
+	  <street>Magyar Tudosok krt. 11.</street>
+	  <city>Budapest</city>
+	  <country>Hungary</country>
+	  <code>1117</code>
+	 </postal>
+	 <email>balazs.a.varga@ericsson.com</email>
+	</address>
+	</author>
+
+    <author fullname="J&aacute;nos Farkas" initials="J." surname="Farkas">
+      <organization>Ericsson</organization>
+      <address>
+        <postal>
+          <street>Magyar Tudosok krt. 11.</street>
+          <city>Budapest</city>
+          <country>Hungary</country>
+          <code>1117</code>
+        </postal>
+        <email>janos.farkas@ericsson.com</email>
+      </address>
+    </author>
+
+		<author fullname="Andrew G. Malis" initials="A.G." surname="Malis">
+      <organization>Malis Consulting</organization>
+      <address>
+        <email>agmalis@gmail.com</email>
+      </address>
+    </author>
+
+    <author fullname="Stewart Bryant" initials="S." surname="Bryant">
+      <organization>Futurewei Technologies</organization>
+      <address>
+        <email>stewart.bryant@gmail.com</email>
+      </address>
+    </author>
+
+  <date />
+  <workgroup>DetNet</workgroup>
+
+  <abstract>
+   <t>
+     This document specifies the Deterministic Networking MPLS data plane
+     when operating over a TSN sub-network. This document does not define 
+	 new procedures or processes.  Whenever this document makes requirements 
+	 statements or recommendations, these are taken from normative text in the 
+	 referenced RFCs.
+   </t>
+  </abstract>
+  </front>
+
+ <middle>
+ <section title="Introduction" anchor="sec_intro">
+  <t>
+    Deterministic Networking (DetNet) is a service that can be offered by a
+    network to DetNet flows.  DetNet provides these flows with a low packet loss
+    rates and assured maximum end-to-end delivery latency.  General background
+    and concepts of DetNet can be found in <xref
+    target="RFC8655"/>.
+  </t>
+  <t>
+    The DetNet Architecture decomposes the DetNet related data plane
+    functions into two sub-layers: a service sub-layer and a forwarding sub-layer.
+    The service sub-layer is used to provide DetNet service protection and
+    reordering. The forwarding sub-layer is used to provides congestion
+    protection (low loss, assured latency, and limited reordering)
+    leveraging MPLS Traffic Engineering mechanisms.
+  </t>
+  <t>
+	<xref target="I-D.ietf-detnet-mpls"/> specifies the DetNet data plane 
+	operation for MPLS-based Packet Switched Network (PSN).  MPLS encapsulated 
+	DetNet flows can be carried over network technologies that can provide the 
+	DetNet required level of service. This document focuses on the scenario 
+	where MPLS (DetNet) nodes are interconnected by a IEEE 802.1 TSN sub-network.
+  </t>
+ </section>
+
+ <section title="Terminology">
+
+  <section title="Terms Used in This Document">
+  <t>
+   This document uses the terminology established in the DetNet architecture
+   <xref target="RFC8655"/> and 
+   <xref target="I-D.ietf-detnet-mpls"/>, and the reader is assumed
+   to be familiar with that document and its terminology.
+  </t>
+  </section>
+
+  <section title="Abbreviations">
+  <t>
+   The following abbreviations are used in this document:
+   <list style="hanging" hangIndent="14">
+    <t hangText="CW">Control Word.</t>
+    <t hangText="DetNet">Deterministic Networking.</t>
+    <t hangText="DF">DetNet Flow.</t>
+    <t hangText="FRER">Frame Replication and Elimination for Redundancy 
+	(TSN function).</t>
+    <t hangText="L2">Layer 2.</t>
+    <t hangText="L3">Layer 3.</t>
+    <t hangText="LSR">Label Switching Router.</t>
+    <t hangText="MPLS">Multiprotocol Label Switching.</t>
+    <t hangText="PE">Provider Edge.</t>
+    <t hangText="PREOF">Packet Replication, Elimination and Ordering Functions.</t>
+    <t hangText="PSN">Packet Switched Network.</t>
+    <t hangText="PW">PseudoWire.</t>
+    <t hangText="S-PE">Switching Provider Edge.</t>
+    <t hangText="T-PE">Terminating Provider Edge.</t>
+    <t hangText="TSN">Time-Sensitive Network.</t>
+   </list>
+  </t>
+  </section>
+  <section title="Requirements Language">
+   <t>
+    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+    "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+    "OPTIONAL" in this document are to be interpreted as described in
+    BCP 14 <xref target="RFC2119"/> <xref target="RFC8174"/> when, and
+    only when, they appear in all capitals, as shown here.
+   </t>
+   </section>
+ </section>  <!-- end of terminology -->
+
+ <section title="DetNet MPLS Data Plane Overview" anchor="sec_dt_dp">
+  <t>
+	The basic approach defined in <xref target="I-D.ietf-detnet-mpls"/>
+	supports the DetNet service sub-layer based on existing pseudowire (PW) 
+	encapsulations and mechanisms, and supports the DetNet forwarding 
+	sub-layer based on existing MPLS Traffic Engineering encapsulations 
+	and mechanisms. 
+  </t>
+ <t>
+  A node operating on a DetNet flow in the Detnet service sub-layer, i.e. 
+  a node processing a DetNet packet which has the S-Label as top of stack uses 
+  the local context associated with that S-Label, for example a received 
+  F-Label, to determine what local DetNet operation(s) are applied to that 
+  packet. An S-Label may be unique when taken from the platform
+  label space <xref target="RFC3031"/>, which would enable correct DetNet flow
+  identification regardless of which input interface or LSP the packet arrives 
+  on. The service sub-layer functions (i.e., PREOF) use a DetNet control word 
+  (d-CW).
+ </t>
+  <t>
+    The DetNet MPLS data plane builds on MPLS Traffic Engineering
+    encapsulations and mechanisms to provide a forwarding sub-layer that
+    is responsible for providing resource allocation and explicit
+    routes.  The forwarding sub-layer is supported by one or more
+    forwarding labels (F-Labels).
+  </t>
+  <t>
+        DetNet edge/relay nodes are DetNet service sub-layer
+        aware, understand the particular needs of DetNet flows and
+        provide both DetNet service and forwarding sub-layer functions.
+        They add, remove and process d-CWs, S-Labels and F-labels as
+        needed.  MPLS DetNet nodes and transit nodes include
+        DetNet forwarding sub-layer functions, support for notably
+        explicit routes, and resources allocation to eliminate (or
+        reduce) congestion loss and jitter. Unlike other DetNet node types, 
+		transit nodes provide no service sub-layer processing.
+  </t>
+  <t>
+		MPLS (DetNet) nodes and transit nodes interconnected by a TSN 
+		sub-network are the primary focus of this document. 
+		The mapping of DetNet MPLS flows to TSN streams and TSN protection 
+		mechanisms are covered in <xref target="mpls-over-tsn"/>.
+  </t>
+  </section>  <!-- end of data plane overview -->
+
+<!-- ===================================================================== -->
+
+<section anchor="mpls-over-tsn"
+         title="DetNet MPLS Operation Over IEEE 802.1 TSN Sub-Networks">
+	<t>
+		The DetNet WG collaborates with IEEE 802.1 TSN in order to define a 
+		common architecture for both Layer 2 and Layer 3, what maintains 
+		consistency across diverse networks. Both DetNet MPLS and TSN use
+		the same techniques to provide their deterministic service:
+		<list style="symbols">
+			<t>
+				Service protection.
+			</t><t>
+				Resource allocation.
+			</t><t>
+				Explicit routes.
+			</t>
+		</list>
+		As described in the DetNet architecture 
+		<xref target="RFC8655"/> a sub-network provides from 
+		MPLS perspective a single hop connection between MPLS (DetNet) nodes. 
+		Functions used for resource allocation and explicit routes 
+		are treated as domain internal functions and does not require function
+		interworking across the DetNet MPLS network and the TSN sub-network. 
+	</t>
+	<t>
+		In case of the service protection function due to the similarities of 
+		the DetNet PREOF and TSN FRER functions some level of interworking is 
+		possible. However, such interworking is out-of-scope in this document 
+		and left for further study.
+	</t>
+    <t>
+      <xref target="fig_mpls_detnet_to_tsn"/> illustrates a scenario, where 
+	  two MPLS (DetNet) nodes are interconnected by a TSN sub-network. Node-1 
+	  is single homed and Node-2 is dual-homed to the TSN sub-network.
+      </t>
+
+<figure align="center" anchor="fig_mpls_detnet_to_tsn"
+              title="DetNet Enabled MPLS Network Over a TSN Sub-Network">
+<artwork><![CDATA[
+   MPLS (DetNet)                 MPLS (DetNet)
+      Node-1                        Node-2
+
+   +----------+                  +----------+
+<--| Service* |-- DetNet flow ---| Service* |-->
+   +----------+                  +----------+
+   |Forwarding|                  |Forwarding|
+   +--------.-+    <-TSN Str->   +-.-----.--+
+             \      ,-------.     /     /
+              +----[ TSN-Sub ]---+     /
+                   [ Network ]--------+
+                    `-------'
+<---------------- DetNet MPLS --------------->
+
+Note: * no service sub-layer required for transit nodes
+]]></artwork>
+      </figure>
+
+	<t>
+		The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1 
+		Working Group have defined (and are defining) a number of amendments 
+		to <xref target="IEEE8021Q">IEEE 802.1Q</xref> that provide zero 
+		congestion loss and bounded latency in bridged networks. Furthermore
+		<xref target="IEEE8021CB">IEEE 802.1CB</xref> defines frame replication
+		and elimination functions for reliability that should prove both 
+		compatible with and useful to, DetNet networks. All these functions 
+		have to identify flows those require TSN treatment.
+    </t>
+    <t>
+        TSN capabilities of the TSN sub-network are made available for MPLS
+        (DetNet) flows via the protocol interworking function defined in Annex C.5 of 
+        <xref target="IEEE8021CB">IEEE 802.1CB</xref>. For example,
+        applied on the TSN edge port it can convert an ingress unicast 
+		MPLS (DetNet) flow to use a specific Layer-2 multicast destination 
+		MAC address and a VLAN, in order to direct the packet through a 
+		specific path inside the bridged network. 
+		A similar interworking function pair at the 
+		other end of the TSN sub-network would restore the packet to its 
+		original Layer-2 destination MAC address and VLAN.
+    </t>
+    <t>
+        Placement of TSN functions depends on the TSN capabilities of
+        nodes. MPLS (DetNet) Nodes may or may not support TSN functions. For
+        a given TSN Stream (i.e., DetNet flow) an MPLS (DetNet) node is
+        treated as a Talker or a Listener inside the TSN sub-network.
+    </t>
+
+          <section title="Functions for DetNet Flow to TSN Stream Mapping">
+            <t>
+              Mapping of a DetNet MPLS flow to a TSN Stream is provided via 
+			  the combination of a passive and an active stream identification 
+			  function that operate at the frame level. The passive stream
+			  identification function is used to catch the MPLS label(s) of a 
+			  DetNet MPLS flow and the active stream identification function 
+			  is used to modify the Ethernet header according to the ID of the 
+			  mapped TSN Stream.  
+            </t>
+            <t>
+			  Clause 6.8 of <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref> defines a
+			  Mask-and-Match Stream identification function that can be used 
+			  as a passive function for MPLS DetNet flows.
+            </t>
+            <t>
+			  Clause 6.6 of <xref target="IEEE8021CB">IEEE 802.1CB</xref> defines an
+              Active Destination MAC and VLAN Stream identification function,
+              what can replace some Ethernet header fields namely (1) the
+              destination MAC-address, (2) the VLAN-ID and (3) priority
+              parameters with alternate values. Replacement is provided for
+              the frame passed down the stack from the upper layers or up the
+              stack from the lower layers.
+            </t>
+            <t>
+              Active Destination MAC and VLAN Stream identification can be
+              used within a Talker to set flow identity or a Listener to
+              recover the original addressing information. It can be used also
+              in a TSN bridge that is providing translation as a proxy service
+              for an End System. 
+            </t>
+		  </section>
+
+          <section title="TSN requirements of MPLS DetNet nodes">
+            <t>
+              This section covers required behavior of a TSN-aware MPLS (DetNet)
+			  node using a TSN sub-network. The implementation of TSN packet 
+			  processing functions must be compliant with the relevant IEEE 802.1 
+			  standards.
+            </t>
+            <t>
+              From the TSN sub-network perspective MPLS (DetNet) nodes are treated 
+			  as Talker or Listener, that may be (1) TSN-unaware or 
+			  (2) TSN-aware.
+            </t>
+            <t>
+              In cases of TSN-unaware MPLS DetNet nodes the TSN relay nodes 
+			  within the TSN sub-network must modify the Ethernet encapsulation 
+			  of the DetNet MPLS flow (e.g., MAC translation, VLAN-ID setting, 
+			  Sequence number addition, etc.) to allow proper TSN specific 
+			  handling inside the sub-network.  There are no requirements 
+			  defined for TSN-unaware MPLS DetNet nodes in this document.
+            </t>
+            <t>
+              MPLS (DetNet) nodes being TSN-aware can be treated as a
+              combination of a TSN-unaware Talker/Listener and a TSN-Relay, as
+              shown in <xref target="fig_mpls_with_tsn"/>.  In such cases the 
+			  MPLS (DetNet) node must provide the TSN sub-network specific 
+			  Ethernet encapsulation over the link(s) towards the sub-network. 
+            </t>
+
+<figure align="center" anchor="fig_mpls_with_tsn"
+              title="MPLS (DetNet) Node with TSN Functions">
+<artwork><![CDATA[
+              MPLS (DetNet)
+                  Node
+   <---------------------------------->
+
+   +----------+
+<--| Service* |-- DetNet flow ------------------
+   +----------+
+   |Forwarding|
+   +----------+    +---------------+
+   |    L2    |    | L2 Relay with |<--- TSN ---
+   |          |    | TSN function  |    Stream
+   +-----.----+    +--.------.---.-+
+          \__________/        \   \______
+                               \_________
+    TSN-unaware
+     Talker /          TSN-Bridge
+     Listener             Relay
+                                       <----- TSN Sub-network -----
+   <------- TSN-aware Tlk/Lstn ------->
+
+Note: * no service sub-layer required for transit nodes
+]]></artwork>
+      </figure>
+
+            <t>
+			  A TSN-aware MPLS (DetNet) node impementations must support the 
+			  Stream Identification TSN component for recognizing flows.
+            </t>
+            <t>
+              A Stream identification component must be able to instantiate
+              the following functions (1) Active Destination MAC and VLAN
+              Stream identification function, 
+			  (2) Mask-and-Match Stream identification function and 
+			  (3) the related managed objects in Clause 9 of
+              <xref target="IEEE8021CB">IEEE 802.1CB</xref> and 
+			  <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref>.
+            </t>
+            <t>
+			  A TSN-aware MPLS (DetNet) node implementations must support the 
+			  Sequencing function and the Sequence encode/decode function as 
+			  defined in  Clause 7.4 and 7.6 of <xref target="IEEE8021CB">IEEE 802.1CB</xref> if FRER 
+			  is used inside the TSN sub-network.
+            </t>
+            <t>
+              The Sequence encode/decode function must support the Redundancy
+              tag (R-TAG) format as per Clause 7.8 of <xref
+              target="IEEE8021CB">IEEE 802.1CB</xref>.
+            </t>
+            <t>
+			  A TSN-aware MPLS (DetNet) node implementations must support the 
+			  Stream splitting 
+			  function and the Individual recovery function as defined in 
+			  Clause 7.7 and 7.5 of <xref target="IEEE8021CB">IEEE 802.1CB</xref> when the node is 
+			  a replication or elimination point for FRER.
+            </t>
+		  </section>
+          <section title="Service protection within the TSN sub-network">
+            <t>
+              TSN Streams supporting DetNet flows may use Frame Replication
+              and Elimination for Redundancy (FRER) as defined in Clause 8. of
+			  <xref target="IEEE8021CB">IEEE 802.1CB</xref> based on the
+              loss service requirements of the TSN Stream, which is derived
+              from the DetNet service requirements of the DetNet mapped flow.
+              The specific operation of FRER is not modified by the use of
+              DetNet and follows <xref target="IEEE8021CB">IEEE
+              802.1CB</xref>.
+            </t>
+            <t>
+              FRER function and the provided service recovery is available
+              only within the TSN sub-network as the TSN Stream-ID and the TSN
+              sequence number are not valid outside the sub-network.  An MPLS
+              (DetNet) node represents a L3 border and as such it terminates
+              all related information elements encoded in the L2 frames.
+            </t>
+			<t>
+			  As the Stream-ID and the TSN sequence number are paired with the 
+			  similar MPLS flow parameters, FRER can be combined with PREOF 
+			  functions. Such service protection interworking scenarios may 
+			  require to move sequence number fields among TSN (L2) and PW 
+			  (MPLS) encapsulations and they are left for further study.
+			</t>
+          </section>
+		  <section title="Aggregation during DetNet flow to TSN Stream mapping">
+            <t>
+			Implementations of this document shall use management and
+			control information to map a DetNet flow to a TSN
+			Stream. N:1 mapping (aggregating DetNet flows in a single
+			TSN Stream) shall be supported. The management or control
+			function that provisions flow mapping shall ensure that
+			adequate resources are allocated and configured to provide
+			proper service requirements of the mapped flows.
+            </t>
+          </section>
+  </section>
+
+<!-- ============================================================= -->
+
+<section title="Management and Control Implications">
+        <t>
+			DetNet flow and TSN Stream mapping related information are
+			required only for TSN-aware MPLS (DetNet) nodes. From the
+			Data Plane perspective there is no practical difference
+			based on the origin of flow mapping related information
+			(management plane or control plane).
+        </t>
+        <t>
+            The following summarizes the set of information that is needed to
+            configure DetNet MPLS over TSN:
+            <list style="symbols">
+			  <t>DetNet MPLS related configuration information according to the 
+			     DetNet role of the DetNet MPLS node, as per 
+			     <xref target="I-D.ietf-detnet-mpls"/>. </t>
+			  <t>TSN related configuration information according to the 
+			     TSN role of the DetNet MPLS node, as per 
+				 <xref target="IEEE8021Q"/>, <xref target="IEEE8021CB"/> and
+			     <xref target="IEEEP8021CBdb"/>. </t>
+              <t>Mapping between DetNet MPLS flow(s) (label information: 
+			  A-labels, S-labels and F-labels as defined in 
+			  <xref target="I-D.ietf-detnet-mpls"/>) and TSN 
+			  Stream(s) (as stream identification information defined in 
+			  <xref target="IEEEP8021CBdb"/>).
+			  Note, that managed objects for TSN Stream identification can be 
+			  found in <xref target="IEEEP8021CBcv"/>.			  
+			  </t>
+            </list>
+            This information must be provisioned per DetNet flow.
+        </t>
+        <t>
+			Mappings between DetNet and TSN management and control planes are 
+			out of scope of the document. Some of the challanges are 
+			highligthed below.
+        </t>
+        <t>
+			TSN-aware MPLS DetNet nodes are member of both the DetNet
+			domain and the TSN sub-network.  Within the TSN
+			sub-network the TSN-aware MPLS (DetNet) node has a TSN-aware
+			Talker/Listener role, so TSN specific management and
+			control plane functionalities must be implemented.  There
+			are many similarities in the management plane techniques
+			used in DetNet and TSN, but that is not the case for the
+			control plane protocols. For example, RSVP-TE and MSRP
+			behaves differently. Therefore management and control
+			plane design is an important aspect of scenarios, where
+			mapping between DetNet and TSN is required.
+	    </t>
+	    <t>
+	      In order to use a TSN sub-network between DetNet nodes,
+	      DetNet specific information must be converted to TSN
+	      sub-network specific ones. DetNet flow ID and flow related
+	      parameters/requirements must be converted to a TSN Stream
+	      ID and stream related parameters/requirements. Note that,
+	      as the TSN sub-network is just a portion of the end2end
+	      DetNet path (i.e., single hop from MPLS perspective), some
+	      parameters (e.g., delay) may differ significantly. Other
+	      parameters (like bandwidth) also may have to be tuned due
+	      to the L2 encapsulation used within the TSN sub-network.
+	    </t>
+	    <t>
+	      In some case it may be challenging to determine some TSN
+	      Stream related information. For example, on a TSN-aware MPLS
+	      (DetNet) node that acts as a Talker, it is quite obvious
+	      which DetNet node is the Listener of the mapped TSN stream
+	      (i.e., the MPLS Next-Hop). However it may be not trivial to
+	      locate the point/interface where that Listener is
+	      connected to the TSN sub-network. Such attributes may
+	      require interaction between control and management plane
+	      functions and between DetNet and TSN domains.
+	    </t>
+        <t>
+	      Mapping between DetNet flow identifiers and TSN Stream
+	      identifiers, if not provided explicitly, can be done by a
+	      TSN-aware MPLS (DetNet) node locally based on information
+	      provided for configuration of the TSN Stream
+	      identification functions (Mask-and-match Stream identification 
+		  and Active Stream identification function).
+	    </t>
+	    <t>
+	      Triggering the setup/modification of a TSN Stream in the
+	      TSN sub-network is an example where management and/or
+	      control plane interactions are required between the DetNet
+	      and TSN sub-network. TSN-unaware MPLS (DetNet) nodes make
+	      such a triggering even more complicated as they are fully
+	      unaware of the sub-network and run independently.
+	    </t>
+	    <t>
+	      Configuration of TSN specific functions (e.g., FRER)
+	      inside the TSN sub-network is a TSN domain specific decision 
+		  and may not be visible in the DetNet domain. Service protection
+		  interworking scenarios are left for further study.
+	    </t>
+</section>
+
+<!-- ===================================================================== -->
+
+<section title="Security Considerations">
+  <t>
+	  Security considerations for DetNet are described in detail in
+	  <xref target="I-D.ietf-detnet-security"/>. General security considerations
+      are described in <xref target="RFC8655"/>. 
+	  DetNet MPLS data plane specific considerations are summarized in 
+	  <xref target="I-D.ietf-detnet-mpls"/>. 
+	  This section considers exclusively security considerations which are 
+	  specific to the DetNet MPLS over TSN sub-network scenario.
+      </t>
+      <t>
+	  The sub-network between DetNet nodes needs to be subject to appropriate 
+	  confidentiality. Additionally, knowledge of what DetNet/TSN services are 
+	  provided by a sub-network may supply information that can be used in a 
+	  variety of security attacks. The ability to modify information exchanges 
+	  between connected DetNet nodes may result in bogus operations. Therefore, 
+	  it is important that the interface between DetNet nodes and TSN 
+	  sub-network are subject to authorization, authentication, and encryption.
+      </t>
+      <t>
+	  The TSN sub-network operates at Layer-2 so various security mechanisms 
+	  defined by IEEE can be used to secure the connection between the DetNet 
+	  nodes (e.g., encryption may be provided using MACSec 
+	  <xref target="IEEE802.1AE-2018"/>).
+  </t>
+</section>
+
+
+<section anchor="iana" title="IANA Considerations">
+  <t>
+   This document makes no IANA requests.
+  </t>
+</section>
+
+<section anchor="acks" title="Acknowledgements">
+   <t>
+		The authors wish to thank Norman Finn, Lou Berger, Craig Gunther,
+		Christophe Mangin and Jouni Korhonen for their various contributions 
+		to this work.
+   </t>
+</section>
+</middle>
+
+<back>
+  <references title="Normative References">
+   &rfc2119;
+   <?rfc include="reference.RFC.3031"?>
+   <?rfc include="reference.RFC.8174"?>
+      <?rfc include="reference.I-D.ietf-detnet-mpls"?>
+  </references>
+  <references title="Informative References">
+      <?rfc include="reference.RFC.8655"?>
+      <?rfc include="reference.I-D.ietf-detnet-ip"?>
+      <?rfc include="reference.I-D.ietf-detnet-security"?>
+   
+    <reference anchor="IEEE802.1AE-2018"
+      target="https://ieeexplore.ieee.org/document/8585421">
+      <front>
+        <title>IEEE Std 802.1AE-2018 MAC Security (MACsec)</title>
+        <author>
+          <organization>IEEE Standards Association</organization>
+        </author>
+        <date year="2018" />
+      </front>
+    </reference>
+
+      <reference anchor="IEEE8021Q"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks--Bridges
+          and Bridged Networks (IEEE Std 802.1Q-2018)</title>
+          <author>
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date year="2018"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
+
+      <reference anchor="IEEE8021CB"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks - 
+		  Frame Replication and Elimination for Reliability 
+		  (IEEE Std 802.1CB-2017)</title>
+          <author>
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date year="2017"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
+
+      <reference anchor="IEEEP8021CBdb"
+                 target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf">
+        <front>
+          <title>Extended Stream identification functions</title>
+          <author initials="C. M." surname="Mangin" fullname="Christophe Mangin">
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date month="September" year="2020"/>
+        </front>
+        <seriesInfo name="IEEE P802.1CBdb /D1.0" value="P802.1CBdb"/>
+        <format type="PDF" target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf"/>
+      </reference>
+
+      <reference anchor="IEEEP8021CBcv"
+                 target="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf">
+        <front>
+          <title>FRER YANG Data Model and Management Information Base Module</title>
+          <author initials="S." surname="Kehrer" fullname="Stephan Kehrer">
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date month="August" year="2020"/>
+        </front>
+        <seriesInfo name="IEEE P802.1CBcv /D0.4" value="P802.1CBcv"/>
+        <format type="PDF" target="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf"/>
+      </reference>
+    </references>
+
+ </back>
+</rfc>

--- a/mpls-over-tsn/draft-ietf-detnet-mpls-over-tsn.xml
+++ b/mpls-over-tsn/draft-ietf-detnet-mpls-over-tsn.xml
@@ -13,7 +13,7 @@
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
 <rfc category="info"
-     docName="draft-ietf-detnet-mpls-over-tsn-04"
+     docName="draft-ietf-detnet-mpls-over-tsn-05"
          ipr="trust200902"
          submissionType="IETF">
   <front>

--- a/mpls-over-tsn/draft-ietf-detnet-mpls-over-tsn.xml
+++ b/mpls-over-tsn/draft-ietf-detnet-mpls-over-tsn.xml
@@ -12,7 +12,7 @@
 <?rfc strict="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
-<rfc category="std"
+<rfc category="info"
      docName="draft-ietf-detnet-mpls-over-tsn-04"
          ipr="trust200902"
          submissionType="IETF">
@@ -66,7 +66,10 @@
   <abstract>
    <t>
      This document specifies the Deterministic Networking MPLS data plane
-     when operating over a TSN sub-network.
+     when operating over a TSN sub-network. This document does not define 
+	 new procedures or processes.  Whenever this document makes requirements 
+	 statements or recommendations, these are taken from normative text in the 
+	 referenced RFCs.
    </t>
   </abstract>
   </front>
@@ -168,58 +171,23 @@
     routes.  The forwarding sub-layer is supported by one or more
     forwarding labels (F-Labels).
   </t>
-
-      <figure align="center" anchor="fig_mpls_detnet_part"
-              title="Part of a Simple DetNet MPLS Network using a TSN sub-net">
-        <artwork><![CDATA[
-      Edge          Transit        Relay       
-      Node           Node           Node        
-     (T-PE)          (LSR)         (S-PE)
-   +---------+                                 
-<--|Svc Proxy|-- End to End Service ----------->
-   +---------+                   +---------+   
-   |IP | |Svc|<-- DetNet flow ---| Service |--->
-   +---+ +---+    +---------+    +---------+   
-   |Fwd| |Fwd|    |   Fwd   |    |Fwd| |Fwd|   
-   +-.-+ +-.-+    +--.----.-+    +-.-+ +-.-+   
-     :    /  ,-----.  \   :  Link  :     :
-.....+    +-[TSN Sub]-+   +........+     +.....
-            [Network]                
-             `-----'                
-        |<----------- LSP ---------->| |<--- LSP -->|
-        |<------------- DetNet MPLS ------------
-                         ]]></artwork>
-      </figure>
-
-      <t>
-        <xref target="fig_mpls_detnet_part"/> illustrates an extract of a 
-        DetNet enabled MPLS network. Edge/relay nodes sit at 
-		MPLS LSP boundaries and transit nodes are LSRs. In this figure, two 
-		MPLS nodes (the edge node and the transit node) are interconnected by 
-		a TSN sub-network.
-      </t>
-      <t>
+  <t>
         DetNet edge/relay nodes are DetNet service sub-layer
         aware, understand the particular needs of DetNet flows and
         provide both DetNet service and forwarding sub-layer functions.
         They add, remove and process d-CWs, S-Labels and F-labels as
-        needed.  MPLS enabled DetNet nodes can enhance the
-        reliability of delivery by enabling the replication of packets
-        where multiple copies, possibly over multiple paths, are
-        forwarded through the DetNet domain.  They can also eliminate
-        surplus previously replicated copies of DetNet packets.
-		MPLS (DetNet) nodes also include
+        needed.  MPLS DetNet nodes and transit nodes include
         DetNet forwarding sub-layer functions, support for notably
         explicit routes, and resources allocation to eliminate (or
-        reduce) congestion loss and jitter.
-      </t>
-      <t>
-        DetNet transit nodes reside wholly within a DetNet domain, and
-        also provide DetNet forwarding sub-layer functions in accordance
-        with the performance required by a DetNet flow carried over an
-        LSP. Unlike other DetNet node types, transit nodes provide no
-        service sub-layer processing.
-      </t>
+        reduce) congestion loss and jitter. Unlike other DetNet node types, 
+		transit nodes provide no service sub-layer processing.
+  </t>
+  <t>
+		MPLS (DetNet) nodes and transit nodes interconnected by a TSN 
+		sub-network are the primary focus of this document. 
+		The mapping of DetNet MPLS flows to TSN streams and TSN protection 
+		mechanisms are covered in <xref target="mpls-over-tsn"/>.
+  </t>
   </section>  <!-- end of data plane overview -->
 
 <!-- ===================================================================== -->
@@ -241,8 +209,7 @@
 			</t>
 		</list>
 		As described in the DetNet architecture 
-		<xref target="RFC8655"/> and also illustrated here 
-		in <xref target="fig_mpls_detnet_part"/> a sub-network provides from 
+		<xref target="RFC8655"/> a sub-network provides from 
 		MPLS perspective a single hop connection between MPLS (DetNet) nodes. 
 		Functions used for resource allocation and explicit routes 
 		are treated as domain internal functions and does not require function
@@ -347,7 +314,7 @@ Note: * no service sub-layer required for transit nodes
             <t>
               This section covers required behavior of a TSN-aware MPLS (DetNet)
 			  node using a TSN sub-network. The implementation of TSN packet 
-			  processing functions MUST be compliant with the relevant IEEE 802.1 
+			  processing functions must be compliant with the relevant IEEE 802.1 
 			  standards.
             </t>
             <t>
@@ -399,11 +366,11 @@ Note: * no service sub-layer required for transit nodes
       </figure>
 
             <t>
-			  A TSN-aware MPLS (DetNet) node impementations MUST support the 
+			  A TSN-aware MPLS (DetNet) node impementations must support the 
 			  Stream Identification TSN component for recognizing flows.
             </t>
             <t>
-              A Stream identification component MUST be able to instantiate
+              A Stream identification component must be able to instantiate
               the following functions (1) Active Destination MAC and VLAN
               Stream identification function, 
 			  (2) Mask-and-Match Stream identification function and 
@@ -412,18 +379,18 @@ Note: * no service sub-layer required for transit nodes
 			  <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref>.
             </t>
             <t>
-			  A TSN-aware MPLS (DetNet) node implementations MUST support the 
+			  A TSN-aware MPLS (DetNet) node implementations must support the 
 			  Sequencing function and the Sequence encode/decode function as 
 			  defined in  Clause 7.4 and 7.6 of <xref target="IEEE8021CB">IEEE 802.1CB</xref> if FRER 
 			  is used inside the TSN sub-network.
             </t>
             <t>
-              The Sequence encode/decode function MUST support the Redundancy
+              The Sequence encode/decode function must support the Redundancy
               tag (R-TAG) format as per Clause 7.8 of <xref
               target="IEEE8021CB">IEEE 802.1CB</xref>.
             </t>
             <t>
-			  A TSN-aware MPLS (DetNet) node implementations MUST support the 
+			  A TSN-aware MPLS (DetNet) node implementations must support the 
 			  Stream splitting 
 			  function and the Individual recovery function as defined in 
 			  Clause 7.7 and 7.5 of <xref target="IEEE8021CB">IEEE 802.1CB</xref> when the node is 
@@ -458,11 +425,11 @@ Note: * no service sub-layer required for transit nodes
           </section>
 		  <section title="Aggregation during DetNet flow to TSN Stream mapping">
             <t>
-			Implementations of this document SHALL use management and
+			Implementations of this document shall use management and
 			control information to map a DetNet flow to a TSN
 			Stream. N:1 mapping (aggregating DetNet flows in a single
-			TSN Stream) SHALL be supported. The management or control
-			function that provisions flow mapping SHALL ensure that
+			TSN Stream) shall be supported. The management or control
+			function that provisions flow mapping shall ensure that
 			adequate resources are allocated and configured to provide
 			proper service requirements of the mapped flows.
             </t>
@@ -499,7 +466,12 @@ Note: * no service sub-layer required for transit nodes
 			  found in <xref target="IEEEP8021CBcv"/>.			  
 			  </t>
             </list>
-            This information MUST be provisioned per DetNet flow.
+            This information must be provisioned per DetNet flow.
+        </t>
+        <t>
+			Mappings between DetNet and TSN management and control planes are 
+			out of scope of the document. Some of the challanges are 
+			highligthed below.
         </t>
         <t>
 			TSN-aware MPLS DetNet nodes are member of both the DetNet
@@ -543,7 +515,7 @@ Note: * no service sub-layer required for transit nodes
 	      TSN-aware MPLS (DetNet) node locally based on information
 	      provided for configuration of the TSN Stream
 	      identification functions (Mask-and-match Stream identification 
-		  and active Stream identification function).
+		  and Active Stream identification function).
 	    </t>
 	    <t>
 	      Triggering the setup/modification of a TSN Stream in the
@@ -629,57 +601,59 @@ Note: * no service sub-layer required for transit nodes
       </front>
     </reference>
 
-   <reference anchor="IEEE8021Q"
-     target="http://standards.ieee.org/about/get/">
-    <front>
-     <title>Standard for Local and metropolitan area networks--Bridges and Bridged Networks (IEEE Std 802.1Q-2014)</title>
-     <author>
-      <organization>IEEE 802.1</organization>
-     </author>
-     <date year="2014"/>
-    </front>
-    <format type="PDF" target="http://standards.ieee.org/about/get/"/>
-   </reference>
-
-   <reference anchor="IEEE8021CB"
-    target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf">
-    <front>
-        <title>Draft Standard for Local and metropolitan area networks - Seamless Redundancy</title>
-        <author initials="N. F." surname="Finn" fullname="Norman Finn">
+      <reference anchor="IEEE8021Q"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks--Bridges
+          and Bridged Networks (IEEE Std 802.1Q-2018)</title>
+          <author>
             <organization>IEEE 802.1</organization>
-        </author>
-        <date month="December" year="2015"/>
-    </front>
-    <seriesInfo name="IEEE P802.1CB /D2.1" value="P802.1CB"/>
-    <format type="PDF" target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf"/>
-   </reference>
+          </author>
+          <date year="2018"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
+
+      <reference anchor="IEEE8021CB"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks - 
+		  Frame Replication and Elimination for Reliability 
+		  (IEEE Std 802.1CB-2017)</title>
+          <author>
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date year="2017"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
 
       <reference anchor="IEEEP8021CBdb"
-                 target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf">
+                 target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf">
         <front>
           <title>Extended Stream identification functions</title>
           <author initials="C. M." surname="Mangin" fullname="Christophe Mangin">
             <organization>IEEE 802.1</organization>
           </author>
-          <date month="August" year="2019"/>
+          <date month="September" year="2020"/>
         </front>
-        <seriesInfo name="IEEE P802.1CBdb /D0.2" value="P802.1CBdb"/>
-        <format type="PDF" target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf"/>
+        <seriesInfo name="IEEE P802.1CBdb /D1.0" value="P802.1CBdb"/>
+        <format type="PDF" target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf"/>
       </reference>
 
       <reference anchor="IEEEP8021CBcv"
-                 target="http://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-3.pdf">
+                 target="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf">
         <front>
           <title>FRER YANG Data Model and Management Information Base Module</title>
           <author initials="S." surname="Kehrer" fullname="Stephan Kehrer">
             <organization>IEEE 802.1</organization>
           </author>
-          <date month="May" year="2020"/>
+          <date month="August" year="2020"/>
         </front>
-        <seriesInfo name="IEEE P802.1CBcv /D0.3" value="P802.1CBcv"/>
-        <format type="PDF" target="http://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-3.pdf"/>
+        <seriesInfo name="IEEE P802.1CBcv /D0.4" value="P802.1CBcv"/>
+        <format type="PDF" target="https://www.ieee802.org/1/files/private/cv-drafts/d0/802-1CBcv-d0-4.pdf"/>
       </reference>
-  </references>
+    </references>
 
  </back>
 </rfc>

--- a/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.html
+++ b/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.html
@@ -1,0 +1,959 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+
+  <title>DetNet Data Plane: IEEE 802.1 Time Sensitive Networking over MPLS</title>
+
+  <style type="text/css" title="Xml2Rfc (sans serif)">
+  /*<![CDATA[*/
+	  a {
+	  text-decoration: none;
+	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
+	  a.smpl {
+	  color: black;
+	  }
+	  a:hover {
+	  text-decoration: underline;
+	  }
+	  a:active {
+	  text-decoration: underline;
+	  }
+	  address {
+	  margin-top: 1em;
+	  margin-left: 2em;
+	  font-style: normal;
+	  }
+	  body {
+	  color: black;
+	  font-family: verdana, helvetica, arial, sans-serif;
+	  font-size: 10pt;
+	  max-width: 55em;
+	  
+	  }
+	  cite {
+	  font-style: normal;
+	  }
+	  dd {
+	  margin-right: 2em;
+	  }
+	  dl {
+	  margin-left: 2em;
+	  }
+	
+	  ul.empty {
+	  list-style-type: none;
+	  }
+	  ul.empty li {
+	  margin-top: .5em;
+	  }
+	  dl p {
+	  margin-left: 0em;
+	  }
+	  dt {
+	  margin-top: .5em;
+	  }
+	  h1 {
+	  font-size: 14pt;
+	  line-height: 21pt;
+	  page-break-after: avoid;
+	  }
+	  h1.np {
+	  page-break-before: always;
+	  }
+	  h1 a {
+	  color: #333333;
+	  }
+	  h2 {
+	  font-size: 12pt;
+	  line-height: 15pt;
+	  page-break-after: avoid;
+	  }
+	  h3, h4, h5, h6 {
+	  font-size: 10pt;
+	  page-break-after: avoid;
+	  }
+	  h2 a, h3 a, h4 a, h5 a, h6 a {
+	  color: black;
+	  }
+	  img {
+	  margin-left: 3em;
+	  }
+	  li {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol p {
+	  margin-left: 0em;
+	  }
+	  p {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  pre {
+	  margin-left: 3em;
+	  background-color: lightyellow;
+	  padding: .25em;
+	  }
+	  pre.text2 {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f0f0f0;
+	  width: 69em;
+	  }
+	  pre.inline {
+	  background-color: white;
+	  padding: 0em;
+	  }
+	  pre.text {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  width: 69em;
+	  }
+	  pre.drawing {
+	  border-style: solid;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  padding: 2em;
+	  }
+	  table {
+	  margin-left: 2em;
+	  }
+	  table.tt {
+	  vertical-align: top;
+	  }
+	  table.full {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.headers {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.tt td {
+	  vertical-align: top;
+	  }
+	  table.full td {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.tt th {
+	  vertical-align: top;
+	  }
+	  table.full th {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.headers th {
+	  border-style: none none inset none;
+	  border-width: 1px;
+	  }
+	  table.left {
+	  margin-right: auto;
+	  }
+	  table.right {
+	  margin-left: auto;
+	  }
+	  table.center {
+	  margin-left: auto;
+	  margin-right: auto;
+	  }
+	  caption {
+	  caption-side: bottom;
+	  font-weight: bold;
+	  font-size: 9pt;
+	  margin-top: .5em;
+	  }
+	
+	  table.header {
+	  border-spacing: 1px;
+	  width: 95%;
+	  font-size: 10pt;
+	  color: white;
+	  }
+	  td.top {
+	  vertical-align: top;
+	  }
+	  td.topnowrap {
+	  vertical-align: top;
+	  white-space: nowrap; 
+	  }
+	  table.header td {
+	  background-color: gray;
+	  width: 50%;
+	  }
+	  table.header a {
+	  color: white;
+	  }
+	  td.reference {
+	  vertical-align: top;
+	  white-space: nowrap;
+	  padding-right: 1em;
+	  }
+	  thead {
+	  display:table-header-group;
+	  }
+	  ul.toc, ul.toc ul {
+	  list-style: none;
+	  margin-left: 1.5em;
+	  margin-right: 0em;
+	  padding-left: 0em;
+	  }
+	  ul.toc li {
+	  line-height: 150%;
+	  font-weight: bold;
+	  font-size: 10pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  ul.toc li li {
+	  line-height: normal;
+	  font-weight: normal;
+	  font-size: 9pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  li.excluded {
+	  font-size: 0pt;
+	  }
+	  ul p {
+	  margin-left: 0em;
+	  }
+	
+	  .comment {
+	  background-color: yellow;
+	  }
+	  .center {
+	  text-align: center;
+	  }
+	  .error {
+	  color: red;
+	  font-style: italic;
+	  font-weight: bold;
+	  }
+	  .figure {
+	  font-weight: bold;
+	  text-align: center;
+	  font-size: 9pt;
+	  }
+	  .filename {
+	  color: #333333;
+	  font-weight: bold;
+	  font-size: 12pt;
+	  line-height: 21pt;
+	  text-align: center;
+	  }
+	  .fn {
+	  font-weight: bold;
+	  }
+	  .hidden {
+	  display: none;
+	  }
+	  .left {
+	  text-align: left;
+	  }
+	  .right {
+	  text-align: right;
+	  }
+	  .title {
+	  color: #990000;
+	  font-size: 18pt;
+	  line-height: 18pt;
+	  font-weight: bold;
+	  text-align: center;
+	  margin-top: 36pt;
+	  }
+	  .vcardline {
+	  display: block;
+	  }
+	  .warning {
+	  font-size: 14pt;
+	  background-color: yellow;
+	  }
+	
+	
+	  @media print {
+	  .noprint {
+		display: none;
+	  }
+	
+	  a {
+		color: black;
+		text-decoration: none;
+	  }
+	
+	  table.header {
+		width: 90%;
+	  }
+	
+	  td.header {
+		width: 50%;
+		color: black;
+		background-color: white;
+		vertical-align: top;
+		font-size: 12pt;
+	  }
+	
+	  ul.toc a::after {
+		content: leader('.') target-counter(attr(href), page);
+	  }
+	
+	  ul.ind li li a {
+		content: target-counter(attr(href), page);
+	  }
+	
+	  .print2col {
+		column-count: 2;
+		-moz-column-count: 2;
+		column-fill: auto;
+	  }
+	  }
+	
+	  @page {
+	  @top-left {
+		   content: "Internet-Draft"; 
+	  } 
+	  @top-right {
+		   content: "December 2010"; 
+	  } 
+	  @top-center {
+		   content: "Abbreviated Title";
+	  } 
+	  @bottom-left {
+		   content: "Doe"; 
+	  } 
+	  @bottom-center {
+		   content: "Expires June 2011"; 
+	  } 
+	  @bottom-right {
+		   content: "[Page " counter(page) "]"; 
+	  } 
+	  }
+	
+	  @page:first { 
+		@top-left {
+		  content: normal;
+		}
+		@top-right {
+		  content: normal;
+		}
+		@top-center {
+		  content: normal;
+		}
+	  }
+  /*]]>*/
+  </style>
+
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.2" rel="Chapter" title="2 Terminology">
+<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Terms Used in This Document">
+<link href="#rfc.section.2.2" rel="Chapter" title="2.2 Abbreviations">
+<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Requirements Language">
+<link href="#rfc.section.3" rel="Chapter" title="3 IEEE 802.1 TSN Over DetNet MPLS Data Plane Scenario">
+<link href="#rfc.section.4" rel="Chapter" title="4 DetNet MPLS Data Plane">
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 Overview">
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 TSN over DetNet MPLS Encapsulation">
+<link href="#rfc.section.5" rel="Chapter" title="5 TSN over MPLS Data Plane Procedures">
+<link href="#rfc.section.5.1" rel="Chapter" title="5.1 Edge Node TSN Procedures">
+<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Edge Node DetNet Service Proxy Procedures">
+<link href="#rfc.section.5.3" rel="Chapter" title="5.3 Edge Node DetNet Service and Forwarding Sub-Layer Procedures">
+<link href="#rfc.section.6" rel="Chapter" title="6 Controller Plane (Management and Control) Considerations">
+<link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations">
+<link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations">
+<link href="#rfc.section.9" rel="Chapter" title="9 Acknowledgements">
+<link href="#rfc.references" rel="Chapter" title="10 References">
+<link href="#rfc.references.1" rel="Chapter" title="10.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="10.2 Informative References">
+<link href="#rfc.authors" rel="Chapter">
+
+
+  <meta name="generator" content="xml2rfc version 2.22.3 - https://tools.ietf.org/tools/xml2rfc" />
+  <link rel="schema.dct" href="http://purl.org/dc/terms/" />
+
+  <meta name="dct.creator" content="Varga, B., Ed., Farkas, J., Malis, A., Bryant, S., and D. Fedyk" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-detnet-tsn-vpn-over-mpls-04" />
+  <meta name="dct.issued" scheme="ISO8601" content="2020-03" />
+  <meta name="dct.abstract" content="This document specifies the Deterministic Networking data plane when TSN networks are interconnected over a DetNet MPLS Network.  " />
+  <meta name="description" content="This document specifies the Deterministic Networking data plane when TSN networks are interconnected over a DetNet MPLS Network.  " />
+
+</head>
+
+<body>
+
+  <table class="header">
+    <tbody>
+    
+    	<tr>
+<td class="left">DetNet</td>
+<td class="right">B. Varga, Ed.</td>
+</tr>
+<tr>
+<td class="left">Internet-Draft</td>
+<td class="right">J. Farkas</td>
+</tr>
+<tr>
+<td class="left">Intended status: Standards Track</td>
+<td class="right">Ericsson</td>
+</tr>
+<tr>
+<td class="left">Expires: May 7, 2021</td>
+<td class="right">A. Malis</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">Malis Consulting</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">S. Bryant</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">Futurewei Technologies</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">D. Fedyk</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">LabN Consulting, L.L.C.</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">November 3, 2020</td>
+</tr>
+
+    	
+    </tbody>
+  </table>
+
+  <p class="title">DetNet Data Plane: IEEE 802.1 Time Sensitive Networking over MPLS<br />
+  <span class="filename">draft-ietf-detnet-tsn-vpn-over-mpls-04</span></p>
+  
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+<p>This document specifies the Deterministic Networking data plane when TSN networks are interconnected over a DetNet MPLS Network.  </p>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
+<p>This Internet-Draft will expire on May 7, 2021.</p>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
+<p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+
+  
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
+  <ul class="toc">
+
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<li>2.   <a href="#rfc.section.2">Terminology</a>
+</li>
+<ul><li>2.1.   <a href="#rfc.section.2.1">Terms Used in This Document</a>
+</li>
+<li>2.2.   <a href="#rfc.section.2.2">Abbreviations</a>
+</li>
+<li>2.3.   <a href="#rfc.section.2.3">Requirements Language</a>
+</li>
+</ul><li>3.   <a href="#rfc.section.3">IEEE 802.1 TSN Over DetNet MPLS Data Plane Scenario</a>
+</li>
+<li>4.   <a href="#rfc.section.4">DetNet MPLS Data Plane</a>
+</li>
+<ul><li>4.1.   <a href="#rfc.section.4.1">Overview</a>
+</li>
+<li>4.2.   <a href="#rfc.section.4.2">TSN over DetNet MPLS Encapsulation</a>
+</li>
+</ul><li>5.   <a href="#rfc.section.5">TSN over MPLS Data Plane Procedures</a>
+</li>
+<ul><li>5.1.   <a href="#rfc.section.5.1">Edge Node TSN Procedures</a>
+</li>
+<li>5.2.   <a href="#rfc.section.5.2">Edge Node DetNet Service Proxy Procedures</a>
+</li>
+<li>5.3.   <a href="#rfc.section.5.3">Edge Node DetNet Service and Forwarding Sub-Layer Procedures</a>
+</li>
+</ul><li>6.   <a href="#rfc.section.6">Controller Plane (Management and Control) Considerations</a>
+</li>
+<li>7.   <a href="#rfc.section.7">Security Considerations</a>
+</li>
+<li>8.   <a href="#rfc.section.8">IANA Considerations</a>
+</li>
+<li>9.   <a href="#rfc.section.9">Acknowledgements</a>
+</li>
+<li>10.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>10.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>10.2.   <a href="#rfc.references.2">Informative References</a>
+</li>
+</ul><li><a href="#rfc.authors">Authors' Addresses</a>
+</li>
+
+
+  </ul>
+
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> <a href="#sec_intro" id="sec_intro">Introduction</a>
+</h1>
+<p id="rfc.section.1.p.1">The Time-Sensitive Networking Task Group (TSN TG) within IEEE 802.1 Working Group deals with deterministic services through IEEE 802 networks.  Deterministic Networking (DetNet) defined by IETF is a service that can be offered by a L3 network to DetNet flows.  General background and concepts of DetNet can be found in <a href="#RFC8655" class="xref">[RFC8655]</a>.  </p>
+<p id="rfc.section.1.p.2">This document specifies the use of a DetNet MPLS network to interconnect TSN nodes/network segments. DetNet MPLS data plane is defined in <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a>.  <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>   </p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> Terminology</h1>
+<h1 id="rfc.section.2.1">
+<a href="#rfc.section.2.1">2.1.</a> Terms Used in This Document</h1>
+<p id="rfc.section.2.1.p.1">This document uses the terminology and concepts established in the DetNet architecture <a href="#RFC8655" class="xref">[RFC8655]</a> and <a href="#I-D.ietf-detnet-data-plane-framework" class="xref">[I-D.ietf-detnet-data-plane-framework]</a>, and <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a>.  The reader is assumed to be familiar with these documents and their terminology.  </p>
+<h1 id="rfc.section.2.2">
+<a href="#rfc.section.2.2">2.2.</a> Abbreviations</h1>
+<p id="rfc.section.2.2.p.1">The following abbreviations are used in this document: </p>
+
+<dl>
+<dt>AC</dt>
+<dd style="margin-left: 14">Attachment Circuit.</dd>
+<dt>CE</dt>
+<dd style="margin-left: 14">Customer Edge equipment.</dd>
+<dt>CW</dt>
+<dd style="margin-left: 14">Control Word.</dd>
+<dt>DetNet</dt>
+<dd style="margin-left: 14">Deterministic Networking.</dd>
+<dt>DF</dt>
+<dd style="margin-left: 14">DetNet Flow.</dd>
+<dt>FRER</dt>
+<dd style="margin-left: 14">Frame Replication and Elimination for Redundancy (TSN function).</dd>
+<dt>L2</dt>
+<dd style="margin-left: 14">Layer 2.</dd>
+<dt>L2VPN</dt>
+<dd style="margin-left: 14">Layer 2 Virtual Private Network.</dd>
+<dt>L3</dt>
+<dd style="margin-left: 14">Layer 3.</dd>
+<dt>LSR</dt>
+<dd style="margin-left: 14">Label Switching Router.</dd>
+<dt>MPLS</dt>
+<dd style="margin-left: 14">Multiprotocol Label Switching.</dd>
+<dt>MPLS-TE</dt>
+<dd style="margin-left: 14">Multiprotocol Label Switching - Traffic Engineering.</dd>
+<dt>MPLS-TP</dt>
+<dd style="margin-left: 14">Multiprotocol Label Switching - Transport Profile.</dd>
+<dt>NSP</dt>
+<dd style="margin-left: 14">Native Service Processing.</dd>
+<dt>OAM</dt>
+<dd style="margin-left: 14">Operations, Administration, and Maintenance.</dd>
+<dt>PE</dt>
+<dd style="margin-left: 14">Provider Edge.</dd>
+<dt>PREOF</dt>
+<dd style="margin-left: 14">Packet Replication, Elimination and Ordering Functions.</dd>
+<dt>PW</dt>
+<dd style="margin-left: 14">PseudoWire.</dd>
+<dt>S-PE</dt>
+<dd style="margin-left: 14">Switching Provider Edge.</dd>
+<dt>T-PE</dt>
+<dd style="margin-left: 14">Terminating Provider Edge.</dd>
+<dt>TSN</dt>
+<dd style="margin-left: 14">Time-Sensitive Network.</dd>
+</dl>
+
+<p> </p>
+<h1 id="rfc.section.2.3">
+<a href="#rfc.section.2.3">2.3.</a> Requirements Language</h1>
+<p id="rfc.section.2.3.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <a href="#RFC2119" class="xref">[RFC2119]</a> <a href="#RFC8174" class="xref">[RFC8174]</a> when, and only when, they appear in all capitals, as shown here.  </p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> <a href="#sec_tsn_mpls_dt_dp_scen" id="sec_tsn_mpls_dt_dp_scen">IEEE 802.1 TSN Over DetNet MPLS Data Plane Scenario</a>
+</h1>
+<p><a href="#fig_tsn_mpls_detnet" class="xref">Figure 1</a> shows IEEE 802.1 TSN end stations operating over a TSN aware DetNet service running over an MPLS network.  DetNet Edge Nodes sit at the boundary of a DetNet domain. They are responsible for mapping non-DetNet aware L2 traffic to DetNet services.  They also support the imposition and disposition of the required DetNet encapsulation.  These are functionally similar to pseudowire (PW) Terminating Provider Edge (T-PE) nodes which use MPLS-TE LSPs.  In this example TSN Streams are simple applications over DetNet flows.  The specific of this operation are discussed later in this document.  </p>
+<div id="rfc.figure.1"></div>
+<div id="fig_tsn_mpls_detnet"></div>
+<pre>
+   TSN           Edge          Transit         Edge          TSN
+End System       Node           Node           Node       End System
+                (T-PE)         (LSR)          (T-PE)
+
++----------+                                             +----------+
+|   TSN    | &lt;---------End to End TSN Service----------&gt; |   TSN    |
+|  Applic. |                                             |  Applic. |
++----------+  +.........+                   +.........+  +----------+
+|          |  | \S-Proxy:                   :S-Proxy/ |  |          |
+|   TSN    |  |   +.+---+&lt;-- DetNet flow --&gt;+---+ |   |  |   TSN    |
+|          |  |TSN| |Svc|                   |Svc| |TSN|  |          |
++----------+  +---+ +---+    +----------+   +---+ +---+  +----------+
+|   L2     |  | L2| |Fwd|    |Forwarding|   |Fwd| |L2 |  |   L2     |
++------.---+  +-.-+ +-.-+    +---.----.-+   +--.+ +-.-+  +---.------+
+       :  Link  :     /  ,-----.  \   :  Link  :   /  ,-----. \
+       +........+     +-[  Sub  ]-+   +........+   +-[  TSN  ]-+
+                        [Network]                    [Network]
+                         `-----'                      `-----'
+
+                    |&lt;------ DetNet MPLS ------&gt;|
+        |&lt;---------------------- TSN   ---------------------&gt;|
+
+</pre>
+<p class="figure">Figure 1: A TSN over DetNet MPLS Enabled Network</p>
+<p id="rfc.section.3.p.2">In this example, edge nodes provide a service proxy function that "associates" the DetNet flows and native flows (i.e., TSN Streams) at the edge of the DetNet domain.  TSN streams are treated as App-flows for DetNet. The whole DetNet domain behaves as a TSN relay node for the TSN streams. The service proxy behaves as a port of that TSN relay node.  </p>
+<p><a href="#fig_8021_detnet" class="xref">Figure 2</a> illustrates how DetNet can provide services for IEEE 802.1 TSN end systems, CE1 and CE2, over a DetNet enabled MPLS network.  Edge nodes, E1 and E2, insert and remove required DetNet data plane encapsulation.  The 'X' in the edge nodes and relay node, R1, represent a potential DetNet compound flow  packet replication and elimination point.  This conceptually parallels L2VPN services, and could leverage existing related solutions as discussed below.  </p>
+<div id="rfc.figure.2"></div>
+<div id="fig_8021_detnet"></div>
+<pre>
+     TSN    |&lt;------- End to End DetNet Service ------&gt;|  TSN
+    Service |         Transit          Transit         | Service
+TSN  (AC)   |        |&lt;-Tnl-&gt;|        |&lt;-Tnl-&gt;|        |  (AC)  TSN
+End    |    V        V    1  V        V   2   V        V   |    End
+System |    +--------+       +--------+       +--------+   |  System
++---+  |    |   E1   |=======|   R1   |=======|   E2   |   |   +---+
+|   |--|----|._X_....|..DF1..|.._ _...|..DF3..|...._X_.|---|---|   |
+|CE1|  |    |    \   |       |   X    |       |   /    |   |   |CE2|
+|   |       |     \_.|..DF2..|._/ \_..|..DF4..|._/     |       |   |
++---+       |        |=======|        |=======|        |       +---+
+    ^       +--------+       +--------+       +--------+       ^
+    |        Edge Node       Relay Node        Edge Node       |
+    |          (T-PE)           (S-PE)          (T-PE)         |
+    |                                                          |
+    |&lt;- TSN -&gt; &lt;------- TSN Over DetNet MPLS -------&gt; &lt;- TSN -&gt;|
+    |                                                          |
+    |&lt;-------- Time Sensitive Networking (TSN) Service -------&gt;|
+
+    X   = Service protection
+    DFx = DetNet member flow x over a TE LSP
+
+</pre>
+<p class="figure">Figure 2: IEEE 802.1TSN Over DetNet</p>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> <a href="#sec_dt_dp" id="sec_dt_dp">DetNet MPLS Data Plane</a>
+</h1>
+<h1 id="rfc.section.4.1">
+<a href="#rfc.section.4.1">4.1.</a> <a href="#sec_dt_dp_ov" id="sec_dt_dp_ov">Overview</a>
+</h1>
+<p id="rfc.section.4.1.p.1">The basic approach defined in <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a> supports the DetNet service sub-layer based on existing pseudowire (PW) encapsulations and mechanisms, and supports the DetNet forwarding sub-layer based on existing MPLS Traffic Engineering encapsulations and mechanisms.  </p>
+<p id="rfc.section.4.1.p.2">A node operating on a DetNet flow in the Detnet service sub-layer, i.e.  a node processing a DetNet packet which has the S-Label as top of stack uses the local context associated with that S-Label, for example a received F-Label, to determine what local DetNet operation(s) are applied to that packet. An S-Label may be unique when taken from the platform label space <a href="#RFC3031" class="xref">[RFC3031]</a>, which would enable correct DetNet flow identification regardless of which input interface or LSP the packet arrives on. The service sub-layer functions (i.e., PREOF) use a DetNet control word (d-CW).  </p>
+<p id="rfc.section.4.1.p.3">The DetNet MPLS data plane builds on MPLS Traffic Engineering encapsulations and mechanisms to provide a forwarding sub-layer that is responsible for providing resource allocation and explicit routes.  The forwarding sub-layer is supported by one or more forwarding labels (F-Labels).  </p>
+<p id="rfc.section.4.1.p.4">DetNet edge/relay nodes are DetNet service sub-layer aware, understand the particular needs of DetNet flows and provide both DetNet service and forwarding sub-layer functions.  They add, remove and process d-CWs, S-Labels and F-labels as needed.  MPLS DetNet nodes and transit nodes include DetNet forwarding sub-layer functions, support for notably explicit routes, and resources allocation to eliminate (or reduce) congestion loss and jitter. Unlike other DetNet node types, transit nodes provide no service sub-layer processing.  </p>
+<h1 id="rfc.section.4.2">
+<a href="#rfc.section.4.2">4.2.</a> <a href="#tom-encap" id="tom-encap">TSN over DetNet MPLS Encapsulation</a>
+</h1>
+<p id="rfc.section.4.2.p.1">The basic encapsulation approach is to treat a TSN Stream as an App-flow from the DetNet MPLS perspective. The corresponding example shown in <a href="#fig_tsn_mpls_ex" class="xref">Figure 3</a>.  </p>
+<div id="rfc.figure.3"></div>
+<div id="fig_tsn_mpls_ex"></div>
+<pre>
+
+           /-&gt;     +------+  +------+  +------+   TSN      ^ ^
+           |       |  X   |  |  X   |  |  X   |&lt;- Appli    : :
+App-Flow &lt;-+       +------+  +------+  +------+   cation   : :(1)
+ for MPLS  |       |TSN-L2|  |TSN-L2|  |TSN-L2|            : v
+           \-&gt; +---+======+--+======+--+======+-----+      :
+                   | d-CW |  | d-CW |  | d-CW |            :
+DetNet-MPLS        +------+  +------+  +------+            :(2)
+                   |Labels|  |Labels|  |Labels|            v
+               +---+======+--+======+--+======+-----+
+Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
+                   +------+  +------+  +------+
+                                       |  IP  |
+                                       +------+
+                                       |  L2  |
+                                       +------+
+    (1) TSN Stream 
+    (2) DetNet MPLS Flow
+    
+        </pre>
+<p class="figure">Figure 3: Example TSN over MPLS Encapsulation Formats</p>
+<p id="rfc.section.4.2.p.2">In the figure, "Application" indicates the application payload carried by the TSN network. "MPLS App-Flow" indicates that the TSN Stream is the payload from the perspective of the DetNet MPLS data plane defined in <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a>. A single DetNet MPLS flow can aggregate multiple TSN Streams.  </p>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> <a href="#tom_proc" id="tom_proc">TSN over MPLS Data Plane Procedures</a>
+</h1>
+<p id="rfc.section.5.p.1">Description of Edge Nodes procedures and functions for TSN over DetNet MPLS scenario follows the concept of <a href="#RFC3985" class="xref">[RFC3985]</a> and covers the Edge Nodes components shown on <a href="#fig_tsn_mpls_detnet" class="xref">Figure 1</a>. In this section the following procedures of DetNet Edge Nodes are described: </p>
+
+<ul>
+<li>TSN related (<a href="#tom_tsn_proc" class="xref">Section 5.1</a>) </li>
+<li>DetNet Service Proxy (<a href="#tom_svc_prx_proc" class="xref">Section 5.2</a>) </li>
+<li>DetNet service and forwarding sub-layer (<a href="#tom_dn_sub_proc" class="xref">Section 5.3</a>) </li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.5.p.2">The sub-sections describe procedures for forwarding packets by DetNet Edge nodes, where such packets are received from either directly connected CEs (TSN nodes) or some other DetNet Edge nodes.  </p>
+<h1 id="rfc.section.5.1">
+<a href="#rfc.section.5.1">5.1.</a> <a href="#tom_tsn_proc" id="tom_tsn_proc">Edge Node TSN Procedures</a>
+</h1>
+<p id="rfc.section.5.1.p.1">The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1 Working Group have defined (and are defining) a number of amendments to <a href="#IEEE8021Q" class="xref">IEEE 802.1Q</a> that provide zero congestion loss and bounded latency in bridged networks.  <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> defines packet replication and elimination functions for a TSN network.  </p>
+<p id="rfc.section.5.1.p.2">The implementation of TSN entity (i.e., TSN packet processing functions) must be compliant with the relevant IEEE 802.1 standards.  </p>
+<p id="rfc.section.5.1.p.3">TSN specific functions are executed on the data received by the DetNet Edge Node from the connected CE before forwarded to connected CE(s) or presentation to the DetNet Service Proxy function for transmission across the DetNet domain, or on the data received from a DetNet PW by a PE before it is output on the Attachment Circuit(s) (AC).  </p>
+<p id="rfc.section.5.1.p.4">TSN packet processing function(s) of Edge Nodes (T-PE) are belonging to the native service processing (NSP) <a href="#RFC3985" class="xref">[RFC3985]</a> block. This is similar to other functionalities being defined by standard bodies other than the IETF (for example in case of Ethernet: stripping, overwriting or adding VLAN tags, etc.). Depending on the TSN role of the Edge Node in the end-to-end TSN service selected TSN functions are supported.  </p>
+<p id="rfc.section.5.1.p.5">When a PE receives a packet from a CE, on a given AC with DetNet service, it first checks via Stream Identification (see Clause 6. of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> and <a href="#IEEEP8021CBdb" class="xref">IEEE P802.1CBdb</a>) whether the packet belongs to a configured TSN Stream (i.e., App-flow from DetNet perspective).  If no Stream ID is matched and no other (VPN) service is configured for the AC then packet MUST be dropped. If there is a matching TSN Stream then the Stream-ID specific TSN functions are executed (e.g., ingress policing, header field manipulation in case of active Stream Identification, FRER, etc.). Source MAC lookup may also be used for local MAC address learning.  </p>
+<p id="rfc.section.5.1.p.6">If the PE decides to forward the packet, the packet MUST be forwarded according to the TSN Stream specific configuration to connected CE(s) (in case of local bridging) and/or to the DetNet Service Proxy (in case of forwarding to remote CE(s) required). If there are no TSN Stream specific forwarding configurations the PE MUST flood the packet to other locally attached CE(s) and to the DetNet Service Proxy. If the administrative policy on the PE does not allow flooding the PE MUST drop the packet.  </p>
+<p id="rfc.section.5.1.p.7">When a TSN entity of the PE receives a packet from the DetNet Service Proxy, it first checks via Stream Identification (see Clause 6. of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> and <a href="#IEEEP8021CBdb" class="xref">IEEE P802.1CBdb</a>) whether the packet belongs to a configured TSN Stream. If no Stream ID is matched then packet is dropped. If there is a matching TSN Stream then the Stream ID specific TSN functions are executed (e.g., header field manipulation in case of active Stream Identification, FRER, etc.). Source MAC lookup may also be used for local MAC address learning.  </p>
+<p id="rfc.section.5.1.p.8">If the PE decides to forward the packet, the packet is forwarded according to the TSN Stream specific configuration to connected CE(s).  If there are no TSN Stream specific forwarding configurations the PE floods the packet to locally attached CE(s). If the administrative policy on the PE does not allow flooding the PE drops the packet.  </p>
+<p id="rfc.section.5.1.p.9">Implementations of this document SHALL use management and control information to ensure TSN specific functions of the Edge Node according to the expectations of the connected TSN network.  </p>
+<h1 id="rfc.section.5.2">
+<a href="#rfc.section.5.2">5.2.</a> <a href="#tom_svc_prx_proc" id="tom_svc_prx_proc">Edge Node DetNet Service Proxy Procedures</a>
+</h1>
+<p id="rfc.section.5.2.p.1">The Service Proxy function maps between App-flows and DetNet flows.  The DetNet Edge Node TSN entity MUST support the TSN Stream identification functions and the related managed objects as defined in Clause 6. and Clause 9. of <a href="#IEEE8021CB" class="xref">IEEE 802.1CB</a> and <a href="#IEEEP8021CBdb" class="xref">IEEE P802.1CBdb</a> to recognize the App-flow related packets.  The Service Proxy presents TSN Streams as an App-flow to a DetNet Flow.  </p>
+<p id="rfc.section.5.2.p.2">When a DetNet Service Proxy receives a packet from the TSN Entity it MUST check whether such an App-flow is present in its mapping table.  If present it associates the internal DetNet flow-ID to the packet and MUST forward it to the DetNet Service and Forwarding sub-layers. If no matching statement is present it MUST drop the packet.  </p>
+<p id="rfc.section.5.2.p.3">When a DetNet Service Proxy receives a packet from the DetNet Service and Forwarding sub-layers it MUST be forwarded to the Edge Node TSN Entity.  </p>
+<p id="rfc.section.5.2.p.4">Implementations of this document SHALL use management and control information to map a TSN Stream to a DetNet flow.  N:1 mapping (aggregating multiple TSN Streams in a single DetNet flow) SHALL be supported. The management or control function that provisions flow mapping SHALL ensure that adequate resources are allocated and configured to provide proper service requirements of the mapped flows.  </p>
+<p id="rfc.section.5.2.p.5">Due to the (intentional) similarities of the DetNet PREOF and TSN FRER functions service protection function interworking is possible between the TSN and the DetNet domains. Such service protection interworking scenarios MAY require to copy sequence number fields from TSN (L2) to PW (MPLS) encapsulation.  However, such interworking is out-of-scope in this document and left for further study.  </p>
+<p id="rfc.section.5.2.p.6">A MPLS DetNet flow is configured to carry any number of TSN flows. The DetNet flow specific bandwidth profile SHOULD match the required bandwidth of the App-flow aggregate.  </p>
+<h1 id="rfc.section.5.3">
+<a href="#rfc.section.5.3">5.3.</a> <a href="#tom_dn_sub_proc" id="tom_dn_sub_proc">Edge Node DetNet Service and Forwarding Sub-Layer Procedures</a>
+</h1>
+<p id="rfc.section.5.3.p.1">In the design of <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a> an MPLS service label (the S-Label), similar to a pseudowire (PW) label <a href="#RFC3985" class="xref">[RFC3985]</a>, is used to identify both the DetNet flow identity and the payload MPLS payload type.  The DetNet sequence number is carried in the DetNet Control word (d-CW) which carries the Data/OAM discriminator as well. In <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a> two sequence number sizes are supported: a 16 bit sequence number and a 28 bit sequence number.  </p>
+<p id="rfc.section.5.3.p.2">PREOF functions and the provided service recovery is available only within the DetNet domain as the DetNet flow-ID and the DetNet sequence number are not valid outside the DetNet network.  MPLS (DetNet) Edge node terminates all related information elements encoded in the MPLS labels.  </p>
+<p id="rfc.section.5.3.p.3">The LSP used to forward the DetNet packet may be of any type (MPLS-LDP, MPLS-TE, MPLS-TP <a href="#RFC5921" class="xref">[RFC5921]</a>, or MPLS-SR <a href="#RFC8660" class="xref">[RFC8660]</a>).  The LSP (F-Label) label and/or the S-Label may be used to indicate the queue processing as well as the forwarding parameters.  </p>
+<p id="rfc.section.5.3.p.4">When a PE receives a packet from the Service Proxy function it MUST add to the packet the DetNet flow-ID specific S-label and create a d-CW. The PE MUST forward the packet according to the configured DetNet Service and Forwarding sub-layer rules to other PE nodes.  </p>
+<p id="rfc.section.5.3.p.5">When a PE receives an MPLS packet from a remote PE, then, after processing the MPLS label stack, if the top MPLS label ends up being a DetNet S-label that was advertised by this node, then the PE MUST forward the packet according to the configured DetNet Service and Forwarding sub-layer rules to other PE nodes or via the Detnet Service Proxy function towards locally connected CE(s).  </p>
+<p id="rfc.section.5.3.p.6">For further details on DetNet Service and Forwarding sub-layers see <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a>.  </p>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> <a href="#cp_considerations" id="cp_considerations">Controller Plane (Management and Control) Considerations</a>
+</h1>
+<p id="rfc.section.6.p.1">TSN Stream(s) to DetNet flow mapping related information are required only for the service proxy function of MPLS (DetNet) Edge nodes.  From the Data Plane perspective there is no practical difference based on the origin of flow mapping related information	(management plane or control plane).  </p>
+<p id="rfc.section.6.p.2">The following summarizes the set of information that is needed to configure TSN over DetNet MPLS: </p>
+
+<ul>
+<li>TSN related configuration information according to the TSN role of the DetNet MPLS node, as per <a href="#IEEE8021Q" class="xref">[IEEE8021Q]</a>, <a href="#IEEE8021CB" class="xref">[IEEE8021CB]</a> and <a href="#IEEEP8021CBdb" class="xref">[IEEEP8021CBdb]</a>. </li>
+<li>DetNet MPLS related configuration information according to the DetNet role of the DetNet MPLS node, as per <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a>. </li>
+<li>App-Flow identification information to map received TSN Stream(s) to the DetNet flow. Parameters of TSN stream identification are defined in <a href="#IEEE8021CB" class="xref">[IEEE8021CB]</a> and <a href="#IEEEP8021CBdb" class="xref">[IEEEP8021CBdb]</a>. </li>
+</ul>
+
+<p> This information MUST be provisioned per DetNet flow.  </p>
+<p id="rfc.section.6.p.3">Mappings between DetNet and TSN management and control planes are out of scope of the document. Some of the challanges are highligthed below.  </p>
+<p id="rfc.section.6.p.4">MPLS DetNet Edge nodes are member of both the DetNet domain and the connected TSN network. From the TSN network perspective the MPLS (DetNet) Edge node has a "TSN relay node" role, so TSN specific management and control plane functionalities must be implemented.  There are many similarities in the management plane techniques used in DetNet and TSN, but that is not the case for the control plane protocols. For example, RSVP-TE and MSRP behaves differently.  Therefore management and control plane design is an important aspect of scenarios, where	mapping between DetNet and TSN is required.  </p>
+<p id="rfc.section.6.p.5">Note that, as the DetNet network is just a portion of the end to end TSN path (i.e., single hop from Ethernet perspective), some parameters (e.g., delay) may differ significantly.  Since there is no interworking function the bandwidth of DetNet network is assumed to be set large enough to handle all TSN Flows it will support.  At the egress of the Detnet Domain the MPLS headers are stripped and the TSN flow continues on as a normal TSN flow.  </p>
+<p id="rfc.section.6.p.6">In order to use a DetNet network to interconnect TSN segments, TSN specific information must be converted to DetNet domain specific ones. TSN Stream ID(s) and stream(s) related parameters/requirements must be converted to a DetNet flow-ID and flow related parameters/requirements.  </p>
+<p id="rfc.section.6.p.7">In some case it may be challenging to determine some egress node related information. For example, it may be not trivial to locate the egress point/interface of a TSN Streams with a multicast destination MAC address. Such scenarios may require interaction between control and management plane functions and between DetNet and TSN domains.  </p>
+<p id="rfc.section.6.p.8">Mapping between DetNet flow identifiers and TSN Stream identifiers, if not provided explicitly, can be done by the service proxy function of an MPLS (DetNet) Edge node locally based on information provided for configuration of the TSN Stream identification functions (e.g., Mask-and-Match Stream identification).  </p>
+<p id="rfc.section.6.p.9">Triggering the setup/modification of a DetNet flow in the DetNet network is an example where management and/or control plane interactions are required between the DetNet and the TSN network.  </p>
+<p id="rfc.section.6.p.10">Configuration of TSN specific functions (e.g., FRER) inside the TSN network is a TSN domain specific decision and may not be visible in the DetNet domain. Service protection interworking scenarios are left for further study.  </p>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> Security Considerations</h1>
+<p id="rfc.section.7.p.1">Security considerations for DetNet are described in detail in <a href="#I-D.ietf-detnet-security" class="xref">[I-D.ietf-detnet-security]</a>. General security considerations are described in <a href="#RFC8655" class="xref">[RFC8655]</a>.  </p>
+<p id="rfc.section.7.p.2">DetNet MPLS data plane specific considerations are summarized and described in <a href="#I-D.ietf-detnet-mpls" class="xref">[I-D.ietf-detnet-mpls]</a> including any application flow types. This document focuses on the scenario where TSN Streams are the application flows for DetNet and it is already covered by those DetNet MPLS data plane security considerations.  </p>
+<h1 id="rfc.section.8">
+<a href="#rfc.section.8">8.</a> <a href="#iana" id="iana">IANA Considerations</a>
+</h1>
+<p id="rfc.section.8.p.1">This document makes no IANA requests.  </p>
+<h1 id="rfc.section.9">
+<a href="#rfc.section.9">9.</a> <a href="#acks" id="acks">Acknowledgements</a>
+</h1>
+<p id="rfc.section.9.p.1">The authors wish to thank Norman Finn, Lou Berger, Craig Gunther, Christophe Mangin and Jouni Korhonen for their various contributions to this work.  </p>
+<h1 id="rfc.references">
+<a href="#rfc.references">10.</a> References</h1>
+<h1 id="rfc.references.1">
+<a href="#rfc.references.1">10.1.</a> Normative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="I-D.ietf-detnet-mpls">[I-D.ietf-detnet-mpls]</b></td>
+<td class="top">
+<a>Varga, B.</a>, <a>Farkas, J.</a>, <a>Berger, L.</a>, <a>Malis, A.</a>, <a>Bryant, S.</a> and <a>J. Korhonen</a>, "<a href="https://tools.ietf.org/html/draft-ietf-detnet-mpls-13">DetNet Data Plane: MPLS</a>", Internet-Draft draft-ietf-detnet-mpls-13, October 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3031">[RFC3031]</b></td>
+<td class="top">
+<a>Rosen, E.</a>, <a>Viswanathan, A.</a> and <a>R. Callon</a>, "<a href="https://tools.ietf.org/html/rfc3031">Multiprotocol Label Switching Architecture</a>", RFC 3031, DOI 10.17487/RFC3031, January 2001.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8174">[RFC8174]</b></td>
+<td class="top">
+<a>Leiba, B.</a>, "<a href="https://tools.ietf.org/html/rfc8174">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a>", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.references.2">
+<a href="#rfc.references.2">10.2.</a> Informative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="I-D.ietf-detnet-data-plane-framework">[I-D.ietf-detnet-data-plane-framework]</b></td>
+<td class="top">
+<a>Varga, B.</a>, <a>Farkas, J.</a>, <a>Berger, L.</a>, <a>Malis, A.</a> and <a>S. Bryant</a>, "<a href="https://tools.ietf.org/html/draft-ietf-detnet-data-plane-framework-06">DetNet Data Plane Framework</a>", Internet-Draft draft-ietf-detnet-data-plane-framework-06, May 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="I-D.ietf-detnet-security">[I-D.ietf-detnet-security]</b></td>
+<td class="top">
+<a>Grossman, E.</a>, <a>Mizrahi, T.</a> and <a>A. Hacker</a>, "<a href="https://tools.ietf.org/html/draft-ietf-detnet-security-12">Deterministic Networking (DetNet) Security Considerations</a>", Internet-Draft draft-ietf-detnet-security-12, October 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEE802.1AE-2018">[IEEE802.1AE-2018]</b></td>
+<td class="top">
+<a>IEEE Standards Association</a>, "<a href="https://ieeexplore.ieee.org/document/8585421">IEEE Std 802.1AE-2018 MAC Security (MACsec)</a>", 2018.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEE8021CB">[IEEE8021CB]</b></td>
+<td class="top">
+<a>IEEE 802.1</a>, "<a href="http://standards.ieee.org/about/get/">Standard for Local and metropolitan area networks - Frame Replication and Elimination for Reliability (IEEE Std 802.1CB-2017)</a>", 2017.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEE8021Q">[IEEE8021Q]</b></td>
+<td class="top">
+<a>IEEE 802.1</a>, "<a href="http://standards.ieee.org/about/get/">Standard for Local and metropolitan area networks--Bridges and Bridged Networks (IEEE Std 802.1Q-2018)</a>", 2018.</td>
+</tr>
+<tr>
+<td class="reference"><b id="IEEEP8021CBdb">[IEEEP8021CBdb]</b></td>
+<td class="top">
+<a title="IEEE 802.1">Mangin, C.</a>, "<a href="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf">Extended Stream identification functions</a>", IEEE P802.1CBdb /D1.0 P802.1CBdb, September 2020.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3985">[RFC3985]</b></td>
+<td class="top">
+<a>Bryant, S.</a> and <a>P. Pate</a>, "<a href="https://tools.ietf.org/html/rfc3985">Pseudo Wire Emulation Edge-to-Edge (PWE3) Architecture</a>", RFC 3985, DOI 10.17487/RFC3985, March 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC4301">[RFC4301]</b></td>
+<td class="top">
+<a>Kent, S.</a> and <a>K. Seo</a>, "<a href="https://tools.ietf.org/html/rfc4301">Security Architecture for the Internet Protocol</a>", RFC 4301, DOI 10.17487/RFC4301, December 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC5921">[RFC5921]</b></td>
+<td class="top">
+<a>Bocci, M.</a>, <a>Bryant, S.</a>, <a>Frost, D.</a>, <a>Levrau, L.</a> and <a>L. Berger</a>, "<a href="https://tools.ietf.org/html/rfc5921">A Framework for MPLS in Transport Networks</a>", RFC 5921, DOI 10.17487/RFC5921, July 2010.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8655">[RFC8655]</b></td>
+<td class="top">
+<a>Finn, N.</a>, <a>Thubert, P.</a>, <a>Varga, B.</a> and <a>J. Farkas</a>, "<a href="https://tools.ietf.org/html/rfc8655">Deterministic Networking Architecture</a>", RFC 8655, DOI 10.17487/RFC8655, October 2019.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC8660">[RFC8660]</b></td>
+<td class="top">
+<a>Bashandy, A.</a>, <a>Filsfils, C.</a>, <a>Previdi, S.</a>, <a>Decraene, B.</a>, <a>Litkowski, S.</a> and <a>R. Shakir</a>, "<a href="https://tools.ietf.org/html/rfc8660">Segment Routing with the MPLS Data Plane</a>", RFC 8660, DOI 10.17487/RFC8660, December 2019.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
+<div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Bal&#225;zs Varga</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Varga</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Ericsson</span>
+	<span class="adr">
+	  <span class="vcardline">Magyar Tudosok krt. 11.</span>
+
+	  <span class="vcardline">
+		<span class="locality">Budapest</span>,  
+		<span class="region"></span>
+		<span class="code">1117</span>
+	  </span>
+	  <span class="country-name vcardline">Hungary</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:balazs.a.varga@ericsson.com">balazs.a.varga@ericsson.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">J&#225;nos Farkas</span> 
+	  <span class="n hidden">
+		<span class="family-name">Farkas</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Ericsson</span>
+	<span class="adr">
+	  <span class="vcardline">Magyar Tudosok krt. 11.</span>
+
+	  <span class="vcardline">
+		<span class="locality">Budapest</span>,  
+		<span class="region"></span>
+		<span class="code">1117</span>
+	  </span>
+	  <span class="country-name vcardline">Hungary</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:janos.farkas@ericsson.com">janos.farkas@ericsson.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Andrew G. Malis</span> 
+	  <span class="n hidden">
+		<span class="family-name">Malis</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Malis Consulting</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:agmalis@gmail.com">agmalis@gmail.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Stewart Bryant</span> 
+	  <span class="n hidden">
+		<span class="family-name">Bryant</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Futurewei Technologies</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:stewart.bryant@gmail.com">stewart.bryant@gmail.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Don Fedyk</span> 
+	  <span class="n hidden">
+		<span class="family-name">Fedyk</span>
+	  </span>
+	</span>
+	<span class="org vcardline">LabN Consulting, L.L.C.</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality"></span> 
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline"></span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:dfedyk@labn.net">dfedyk@labn.net</a></span>
+
+  </address>
+</div>
+
+</body>
+</html>

--- a/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.html
+++ b/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.html
@@ -426,7 +426,7 @@
 <td class="right">Ericsson</td>
 </tr>
 <tr>
-<td class="left">Expires: May 7, 2021</td>
+<td class="left">Expires: May 6, 2021</td>
 <td class="right">A. Malis</td>
 </tr>
 <tr>
@@ -451,7 +451,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">November 3, 2020</td>
+<td class="right">November 2, 2020</td>
 </tr>
 
     	
@@ -467,7 +467,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on May 7, 2021.</p>
+<p>This Internet-Draft will expire on May 6, 2021.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>

--- a/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.txt
+++ b/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.txt
@@ -1,0 +1,840 @@
+
+
+
+
+DetNet                                                     B. Varga, Ed.
+Internet-Draft                                                 J. Farkas
+Intended status: Standards Track                                Ericsson
+Expires: May 7, 2021                                            A. Malis
+                                                        Malis Consulting
+                                                               S. Bryant
+                                                  Futurewei Technologies
+                                                                D. Fedyk
+                                                 LabN Consulting, L.L.C.
+                                                        November 3, 2020
+
+
+   DetNet Data Plane: IEEE 802.1 Time Sensitive Networking over MPLS
+                 draft-ietf-detnet-tsn-vpn-over-mpls-04
+
+Abstract
+
+   This document specifies the Deterministic Networking data plane when
+   TSN networks are interconnected over a DetNet MPLS Network.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on May 7, 2021.
+
+Copyright Notice
+
+   Copyright (c) 2020 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 1]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   3
+     2.1.  Terms Used in This Document . . . . . . . . . . . . . . .   3
+     2.2.  Abbreviations . . . . . . . . . . . . . . . . . . . . . .   3
+     2.3.  Requirements Language . . . . . . . . . . . . . . . . . .   4
+   3.  IEEE 802.1 TSN Over DetNet MPLS Data Plane Scenario . . . . .   4
+   4.  DetNet MPLS Data Plane  . . . . . . . . . . . . . . . . . . .   6
+     4.1.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   6
+     4.2.  TSN over DetNet MPLS Encapsulation  . . . . . . . . . . .   7
+   5.  TSN over MPLS Data Plane Procedures . . . . . . . . . . . . .   8
+     5.1.  Edge Node TSN Procedures  . . . . . . . . . . . . . . . .   8
+     5.2.  Edge Node DetNet Service Proxy Procedures . . . . . . . .   9
+     5.3.  Edge Node DetNet Service and Forwarding Sub-Layer
+           Procedures  . . . . . . . . . . . . . . . . . . . . . . .  10
+   6.  Controller Plane (Management and Control) Considerations  . .  11
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
+   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  13
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  13
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  14
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  15
+
+1.  Introduction
+
+   The Time-Sensitive Networking Task Group (TSN TG) within IEEE 802.1
+   Working Group deals with deterministic services through IEEE 802
+   networks.  Deterministic Networking (DetNet) defined by IETF is a
+   service that can be offered by a L3 network to DetNet flows.  General
+   background and concepts of DetNet can be found in [RFC8655].
+
+   This document specifies the use of a DetNet MPLS network to
+   interconnect TSN nodes/network segments.  DetNet MPLS data plane is
+   defined in [I-D.ietf-detnet-mpls].
+
+
+
+
+
+
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 2]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+2.  Terminology
+
+2.1.  Terms Used in This Document
+
+   This document uses the terminology and concepts established in the
+   DetNet architecture [RFC8655] and
+   [I-D.ietf-detnet-data-plane-framework], and [I-D.ietf-detnet-mpls].
+   The reader is assumed to be familiar with these documents and their
+   terminology.
+
+2.2.  Abbreviations
+
+   The following abbreviations are used in this document:
+
+   AC            Attachment Circuit.
+
+   CE            Customer Edge equipment.
+
+   CW            Control Word.
+
+   DetNet        Deterministic Networking.
+
+   DF            DetNet Flow.
+
+   FRER          Frame Replication and Elimination for Redundancy (TSN
+                 function).
+
+   L2            Layer 2.
+
+   L2VPN         Layer 2 Virtual Private Network.
+
+   L3            Layer 3.
+
+   LSR           Label Switching Router.
+
+   MPLS          Multiprotocol Label Switching.
+
+   MPLS-TE       Multiprotocol Label Switching - Traffic Engineering.
+
+   MPLS-TP       Multiprotocol Label Switching - Transport Profile.
+
+   NSP           Native Service Processing.
+
+   OAM           Operations, Administration, and Maintenance.
+
+   PE            Provider Edge.
+
+   PREOF         Packet Replication, Elimination and Ordering Functions.
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 3]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+   PW            PseudoWire.
+
+   S-PE          Switching Provider Edge.
+
+   T-PE          Terminating Provider Edge.
+
+   TSN           Time-Sensitive Network.
+
+2.3.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+3.  IEEE 802.1 TSN Over DetNet MPLS Data Plane Scenario
+
+   Figure 1 shows IEEE 802.1 TSN end stations operating over a TSN aware
+   DetNet service running over an MPLS network.  DetNet Edge Nodes sit
+   at the boundary of a DetNet domain.  They are responsible for mapping
+   non-DetNet aware L2 traffic to DetNet services.  They also support
+   the imposition and disposition of the required DetNet encapsulation.
+   These are functionally similar to pseudowire (PW) Terminating
+   Provider Edge (T-PE) nodes which use MPLS-TE LSPs.  In this example
+   TSN Streams are simple applications over DetNet flows.  The specific
+   of this operation are discussed later in this document.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 4]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+      TSN           Edge          Transit         Edge          TSN
+   End System       Node           Node           Node       End System
+                   (T-PE)         (LSR)          (T-PE)
+
+   +----------+                                             +----------+
+   |   TSN    | <---------End to End TSN Service----------> |   TSN    |
+   |  Applic. |                                             |  Applic. |
+   +----------+  +.........+                   +.........+  +----------+
+   |          |  | \S-Proxy:                   :S-Proxy/ |  |          |
+   |   TSN    |  |   +.+---+<-- DetNet flow -->+---+ |   |  |   TSN    |
+   |          |  |TSN| |Svc|                   |Svc| |TSN|  |          |
+   +----------+  +---+ +---+    +----------+   +---+ +---+  +----------+
+   |   L2     |  | L2| |Fwd|    |Forwarding|   |Fwd| |L2 |  |   L2     |
+   +------.---+  +-.-+ +-.-+    +---.----.-+   +--.+ +-.-+  +---.------+
+          :  Link  :     /  ,-----.  \   :  Link  :   /  ,-----. \
+          +........+     +-[  Sub  ]-+   +........+   +-[  TSN  ]-+
+                           [Network]                    [Network]
+                            `-----'                      `-----'
+
+                       |<------ DetNet MPLS ------>|
+           |<---------------------- TSN   --------------------->|
+
+
+             Figure 1: A TSN over DetNet MPLS Enabled Network
+
+   In this example, edge nodes provide a service proxy function that
+   "associates" the DetNet flows and native flows (i.e., TSN Streams) at
+   the edge of the DetNet domain.  TSN streams are treated as App-flows
+   for DetNet.  The whole DetNet domain behaves as a TSN relay node for
+   the TSN streams.  The service proxy behaves as a port of that TSN
+   relay node.
+
+   Figure 2 illustrates how DetNet can provide services for IEEE 802.1
+   TSN end systems, CE1 and CE2, over a DetNet enabled MPLS network.
+   Edge nodes, E1 and E2, insert and remove required DetNet data plane
+   encapsulation.  The 'X' in the edge nodes and relay node, R1,
+   represent a potential DetNet compound flow packet replication and
+   elimination point.  This conceptually parallels L2VPN services, and
+   could leverage existing related solutions as discussed below.
+
+
+
+
+
+
+
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 5]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+        TSN    |<------- End to End DetNet Service ------>|  TSN
+       Service |         Transit          Transit         | Service
+   TSN  (AC)   |        |<-Tnl->|        |<-Tnl->|        |  (AC)  TSN
+   End    |    V        V    1  V        V   2   V        V   |    End
+   System |    +--------+       +--------+       +--------+   |  System
+   +---+  |    |   E1   |=======|   R1   |=======|   E2   |   |   +---+
+   |   |--|----|._X_....|..DF1..|.._ _...|..DF3..|...._X_.|---|---|   |
+   |CE1|  |    |    \   |       |   X    |       |   /    |   |   |CE2|
+   |   |       |     \_.|..DF2..|._/ \_..|..DF4..|._/     |       |   |
+   +---+       |        |=======|        |=======|        |       +---+
+       ^       +--------+       +--------+       +--------+       ^
+       |        Edge Node       Relay Node        Edge Node       |
+       |          (T-PE)           (S-PE)          (T-PE)         |
+       |                                                          |
+       |<- TSN -> <------- TSN Over DetNet MPLS -------> <- TSN ->|
+       |                                                          |
+       |<-------- Time Sensitive Networking (TSN) Service ------->|
+
+       X   = Service protection
+       DFx = DetNet member flow x over a TE LSP
+
+
+                    Figure 2: IEEE 802.1TSN Over DetNet
+
+4.  DetNet MPLS Data Plane
+
+4.1.  Overview
+
+   The basic approach defined in [I-D.ietf-detnet-mpls] supports the
+   DetNet service sub-layer based on existing pseudowire (PW)
+   encapsulations and mechanisms, and supports the DetNet forwarding
+   sub-layer based on existing MPLS Traffic Engineering encapsulations
+   and mechanisms.
+
+   A node operating on a DetNet flow in the Detnet service sub-layer,
+   i.e.  a node processing a DetNet packet which has the S-Label as top
+   of stack uses the local context associated with that S-Label, for
+   example a received F-Label, to determine what local DetNet
+   operation(s) are applied to that packet.  An S-Label may be unique
+   when taken from the platform label space [RFC3031], which would
+   enable correct DetNet flow identification regardless of which input
+   interface or LSP the packet arrives on.  The service sub-layer
+   functions (i.e., PREOF) use a DetNet control word (d-CW).
+
+   The DetNet MPLS data plane builds on MPLS Traffic Engineering
+   encapsulations and mechanisms to provide a forwarding sub-layer that
+   is responsible for providing resource allocation and explicit routes.
+
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 6]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+   The forwarding sub-layer is supported by one or more forwarding
+   labels (F-Labels).
+
+   DetNet edge/relay nodes are DetNet service sub-layer aware,
+   understand the particular needs of DetNet flows and provide both
+   DetNet service and forwarding sub-layer functions.  They add, remove
+   and process d-CWs, S-Labels and F-labels as needed.  MPLS DetNet
+   nodes and transit nodes include DetNet forwarding sub-layer
+   functions, support for notably explicit routes, and resources
+   allocation to eliminate (or reduce) congestion loss and jitter.
+   Unlike other DetNet node types, transit nodes provide no service sub-
+   layer processing.
+
+4.2.  TSN over DetNet MPLS Encapsulation
+
+   The basic encapsulation approach is to treat a TSN Stream as an App-
+   flow from the DetNet MPLS perspective.  The corresponding example
+   shown in Figure 3.
+
+
+                /->     +------+  +------+  +------+   TSN      ^ ^
+                |       |  X   |  |  X   |  |  X   |<- Appli    : :
+     App-Flow <-+       +------+  +------+  +------+   cation   : :(1)
+      for MPLS  |       |TSN-L2|  |TSN-L2|  |TSN-L2|            : v
+                \-> +---+======+--+======+--+======+-----+      :
+                        | d-CW |  | d-CW |  | d-CW |            :
+     DetNet-MPLS        +------+  +------+  +------+            :(2)
+                        |Labels|  |Labels|  |Labels|            v
+                    +---+======+--+======+--+======+-----+
+     Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
+                        +------+  +------+  +------+
+                                            |  IP  |
+                                            +------+
+                                            |  L2  |
+                                            +------+
+         (1) TSN Stream
+         (2) DetNet MPLS Flow
+
+
+           Figure 3: Example TSN over MPLS Encapsulation Formats
+
+   In the figure, "Application" indicates the application payload
+   carried by the TSN network.  "MPLS App-Flow" indicates that the TSN
+   Stream is the payload from the perspective of the DetNet MPLS data
+   plane defined in [I-D.ietf-detnet-mpls].  A single DetNet MPLS flow
+   can aggregate multiple TSN Streams.
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 7]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+5.  TSN over MPLS Data Plane Procedures
+
+   Description of Edge Nodes procedures and functions for TSN over
+   DetNet MPLS scenario follows the concept of [RFC3985] and covers the
+   Edge Nodes components shown on Figure 1.  In this section the
+   following procedures of DetNet Edge Nodes are described:
+
+   o  TSN related (Section 5.1)
+
+   o  DetNet Service Proxy (Section 5.2)
+
+   o  DetNet service and forwarding sub-layer (Section 5.3)
+
+   The sub-sections describe procedures for forwarding packets by DetNet
+   Edge nodes, where such packets are received from either directly
+   connected CEs (TSN nodes) or some other DetNet Edge nodes.
+
+5.1.  Edge Node TSN Procedures
+
+   The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1
+   Working Group have defined (and are defining) a number of amendments
+   to IEEE 802.1Q [IEEE8021Q] that provide zero congestion loss and
+   bounded latency in bridged networks.  IEEE 802.1CB [IEEE8021CB]
+   defines packet replication and elimination functions for a TSN
+   network.
+
+   The implementation of TSN entity (i.e., TSN packet processing
+   functions) must be compliant with the relevant IEEE 802.1 standards.
+
+   TSN specific functions are executed on the data received by the
+   DetNet Edge Node from the connected CE before forwarded to connected
+   CE(s) or presentation to the DetNet Service Proxy function for
+   transmission across the DetNet domain, or on the data received from a
+   DetNet PW by a PE before it is output on the Attachment Circuit(s)
+   (AC).
+
+   TSN packet processing function(s) of Edge Nodes (T-PE) are belonging
+   to the native service processing (NSP) [RFC3985] block.  This is
+   similar to other functionalities being defined by standard bodies
+   other than the IETF (for example in case of Ethernet: stripping,
+   overwriting or adding VLAN tags, etc.).  Depending on the TSN role of
+   the Edge Node in the end-to-end TSN service selected TSN functions
+   are supported.
+
+   When a PE receives a packet from a CE, on a given AC with DetNet
+   service, it first checks via Stream Identification (see Clause 6. of
+   IEEE 802.1CB [IEEE8021CB] and IEEE P802.1CBdb [IEEEP8021CBdb])
+   whether the packet belongs to a configured TSN Stream (i.e., App-flow
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 8]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+   from DetNet perspective).  If no Stream ID is matched and no other
+   (VPN) service is configured for the AC then packet MUST be dropped.
+   If there is a matching TSN Stream then the Stream-ID specific TSN
+   functions are executed (e.g., ingress policing, header field
+   manipulation in case of active Stream Identification, FRER, etc.).
+   Source MAC lookup may also be used for local MAC address learning.
+
+   If the PE decides to forward the packet, the packet MUST be forwarded
+   according to the TSN Stream specific configuration to connected CE(s)
+   (in case of local bridging) and/or to the DetNet Service Proxy (in
+   case of forwarding to remote CE(s) required).  If there are no TSN
+   Stream specific forwarding configurations the PE MUST flood the
+   packet to other locally attached CE(s) and to the DetNet Service
+   Proxy.  If the administrative policy on the PE does not allow
+   flooding the PE MUST drop the packet.
+
+   When a TSN entity of the PE receives a packet from the DetNet Service
+   Proxy, it first checks via Stream Identification (see Clause 6. of
+   IEEE 802.1CB [IEEE8021CB] and IEEE P802.1CBdb [IEEEP8021CBdb])
+   whether the packet belongs to a configured TSN Stream.  If no Stream
+   ID is matched then packet is dropped.  If there is a matching TSN
+   Stream then the Stream ID specific TSN functions are executed (e.g.,
+   header field manipulation in case of active Stream Identification,
+   FRER, etc.).  Source MAC lookup may also be used for local MAC
+   address learning.
+
+   If the PE decides to forward the packet, the packet is forwarded
+   according to the TSN Stream specific configuration to connected
+   CE(s).  If there are no TSN Stream specific forwarding configurations
+   the PE floods the packet to locally attached CE(s).  If the
+   administrative policy on the PE does not allow flooding the PE drops
+   the packet.
+
+   Implementations of this document SHALL use management and control
+   information to ensure TSN specific functions of the Edge Node
+   according to the expectations of the connected TSN network.
+
+5.2.  Edge Node DetNet Service Proxy Procedures
+
+   The Service Proxy function maps between App-flows and DetNet flows.
+   The DetNet Edge Node TSN entity MUST support the TSN Stream
+   identification functions and the related managed objects as defined
+   in Clause 6. and Clause 9. of IEEE 802.1CB [IEEE8021CB] and IEEE
+   P802.1CBdb [IEEEP8021CBdb] to recognize the App-flow related packets.
+   The Service Proxy presents TSN Streams as an App-flow to a DetNet
+   Flow.
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                  [Page 9]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+   When a DetNet Service Proxy receives a packet from the TSN Entity it
+   MUST check whether such an App-flow is present in its mapping table.
+   If present it associates the internal DetNet flow-ID to the packet
+   and MUST forward it to the DetNet Service and Forwarding sub-layers.
+   If no matching statement is present it MUST drop the packet.
+
+   When a DetNet Service Proxy receives a packet from the DetNet Service
+   and Forwarding sub-layers it MUST be forwarded to the Edge Node TSN
+   Entity.
+
+   Implementations of this document SHALL use management and control
+   information to map a TSN Stream to a DetNet flow.  N:1 mapping
+   (aggregating multiple TSN Streams in a single DetNet flow) SHALL be
+   supported.  The management or control function that provisions flow
+   mapping SHALL ensure that adequate resources are allocated and
+   configured to provide proper service requirements of the mapped
+   flows.
+
+   Due to the (intentional) similarities of the DetNet PREOF and TSN
+   FRER functions service protection function interworking is possible
+   between the TSN and the DetNet domains.  Such service protection
+   interworking scenarios MAY require to copy sequence number fields
+   from TSN (L2) to PW (MPLS) encapsulation.  However, such interworking
+   is out-of-scope in this document and left for further study.
+
+   A MPLS DetNet flow is configured to carry any number of TSN flows.
+   The DetNet flow specific bandwidth profile SHOULD match the required
+   bandwidth of the App-flow aggregate.
+
+5.3.  Edge Node DetNet Service and Forwarding Sub-Layer Procedures
+
+   In the design of [I-D.ietf-detnet-mpls] an MPLS service label (the
+   S-Label), similar to a pseudowire (PW) label [RFC3985], is used to
+   identify both the DetNet flow identity and the payload MPLS payload
+   type.  The DetNet sequence number is carried in the DetNet Control
+   word (d-CW) which carries the Data/OAM discriminator as well.  In
+   [I-D.ietf-detnet-mpls] two sequence number sizes are supported: a 16
+   bit sequence number and a 28 bit sequence number.
+
+   PREOF functions and the provided service recovery is available only
+   within the DetNet domain as the DetNet flow-ID and the DetNet
+   sequence number are not valid outside the DetNet network.  MPLS
+   (DetNet) Edge node terminates all related information elements
+   encoded in the MPLS labels.
+
+   The LSP used to forward the DetNet packet may be of any type (MPLS-
+   LDP, MPLS-TE, MPLS-TP [RFC5921], or MPLS-SR [RFC8660]).  The LSP
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 10]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+   (F-Label) label and/or the S-Label may be used to indicate the queue
+   processing as well as the forwarding parameters.
+
+   When a PE receives a packet from the Service Proxy function it MUST
+   add to the packet the DetNet flow-ID specific S-label and create a
+   d-CW.  The PE MUST forward the packet according to the configured
+   DetNet Service and Forwarding sub-layer rules to other PE nodes.
+
+   When a PE receives an MPLS packet from a remote PE, then, after
+   processing the MPLS label stack, if the top MPLS label ends up being
+   a DetNet S-label that was advertised by this node, then the PE MUST
+   forward the packet according to the configured DetNet Service and
+   Forwarding sub-layer rules to other PE nodes or via the Detnet
+   Service Proxy function towards locally connected CE(s).
+
+   For further details on DetNet Service and Forwarding sub-layers see
+   [I-D.ietf-detnet-mpls].
+
+6.  Controller Plane (Management and Control) Considerations
+
+   TSN Stream(s) to DetNet flow mapping related information are required
+   only for the service proxy function of MPLS (DetNet) Edge nodes.
+   From the Data Plane perspective there is no practical difference
+   based on the origin of flow mapping related information (management
+   plane or control plane).
+
+   The following summarizes the set of information that is needed to
+   configure TSN over DetNet MPLS:
+
+   o  TSN related configuration information according to the TSN role of
+      the DetNet MPLS node, as per [IEEE8021Q], [IEEE8021CB] and
+      [IEEEP8021CBdb].
+
+   o  DetNet MPLS related configuration information according to the
+      DetNet role of the DetNet MPLS node, as per
+      [I-D.ietf-detnet-mpls].
+
+   o  App-Flow identification information to map received TSN Stream(s)
+      to the DetNet flow.  Parameters of TSN stream identification are
+      defined in [IEEE8021CB] and [IEEEP8021CBdb].
+
+   This information MUST be provisioned per DetNet flow.
+
+   Mappings between DetNet and TSN management and control planes are out
+   of scope of the document.  Some of the challanges are highligthed
+   below.
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 11]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+   MPLS DetNet Edge nodes are member of both the DetNet domain and the
+   connected TSN network.  From the TSN network perspective the MPLS
+   (DetNet) Edge node has a "TSN relay node" role, so TSN specific
+   management and control plane functionalities must be implemented.
+   There are many similarities in the management plane techniques used
+   in DetNet and TSN, but that is not the case for the control plane
+   protocols.  For example, RSVP-TE and MSRP behaves differently.
+   Therefore management and control plane design is an important aspect
+   of scenarios, where mapping between DetNet and TSN is required.
+
+   Note that, as the DetNet network is just a portion of the end to end
+   TSN path (i.e., single hop from Ethernet perspective), some
+   parameters (e.g., delay) may differ significantly.  Since there is no
+   interworking function the bandwidth of DetNet network is assumed to
+   be set large enough to handle all TSN Flows it will support.  At the
+   egress of the Detnet Domain the MPLS headers are stripped and the TSN
+   flow continues on as a normal TSN flow.
+
+   In order to use a DetNet network to interconnect TSN segments, TSN
+   specific information must be converted to DetNet domain specific
+   ones.  TSN Stream ID(s) and stream(s) related parameters/requirements
+   must be converted to a DetNet flow-ID and flow related parameters/
+   requirements.
+
+   In some case it may be challenging to determine some egress node
+   related information.  For example, it may be not trivial to locate
+   the egress point/interface of a TSN Streams with a multicast
+   destination MAC address.  Such scenarios may require interaction
+   between control and management plane functions and between DetNet and
+   TSN domains.
+
+   Mapping between DetNet flow identifiers and TSN Stream identifiers,
+   if not provided explicitly, can be done by the service proxy function
+   of an MPLS (DetNet) Edge node locally based on information provided
+   for configuration of the TSN Stream identification functions (e.g.,
+   Mask-and-Match Stream identification).
+
+   Triggering the setup/modification of a DetNet flow in the DetNet
+   network is an example where management and/or control plane
+   interactions are required between the DetNet and the TSN network.
+
+   Configuration of TSN specific functions (e.g., FRER) inside the TSN
+   network is a TSN domain specific decision and may not be visible in
+   the DetNet domain.  Service protection interworking scenarios are
+   left for further study.
+
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 12]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+7.  Security Considerations
+
+   Security considerations for DetNet are described in detail in
+   [I-D.ietf-detnet-security].  General security considerations are
+   described in [RFC8655].
+
+   DetNet MPLS data plane specific considerations are summarized and
+   described in [I-D.ietf-detnet-mpls] including any application flow
+   types.  This document focuses on the scenario where TSN Streams are
+   the application flows for DetNet and it is already covered by those
+   DetNet MPLS data plane security considerations.
+
+8.  IANA Considerations
+
+   This document makes no IANA requests.
+
+9.  Acknowledgements
+
+   The authors wish to thank Norman Finn, Lou Berger, Craig Gunther,
+   Christophe Mangin and Jouni Korhonen for their various contributions
+   to this work.
+
+10.  References
+
+10.1.  Normative References
+
+   [I-D.ietf-detnet-mpls]
+              Varga, B., Farkas, J., Berger, L., Malis, A., Bryant, S.,
+              and J. Korhonen, "DetNet Data Plane: MPLS", draft-ietf-
+              detnet-mpls-13 (work in progress), October 2020.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3031]  Rosen, E., Viswanathan, A., and R. Callon, "Multiprotocol
+              Label Switching Architecture", RFC 3031,
+              DOI 10.17487/RFC3031, January 2001,
+              <https://www.rfc-editor.org/info/rfc3031>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+
+
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 13]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+10.2.  Informative References
+
+   [I-D.ietf-detnet-data-plane-framework]
+              Varga, B., Farkas, J., Berger, L., Malis, A., and S.
+              Bryant, "DetNet Data Plane Framework", draft-ietf-detnet-
+              data-plane-framework-06 (work in progress), May 2020.
+
+   [I-D.ietf-detnet-security]
+              Grossman, E., Mizrahi, T., and A. Hacker, "Deterministic
+              Networking (DetNet) Security Considerations", draft-ietf-
+              detnet-security-12 (work in progress), October 2020.
+
+   [IEEE802.1AE-2018]
+              IEEE Standards Association, "IEEE Std 802.1AE-2018 MAC
+              Security (MACsec)", 2018,
+              <https://ieeexplore.ieee.org/document/8585421>.
+
+   [IEEE8021CB]
+              IEEE 802.1, "Standard for Local and metropolitan area
+              networks - Frame Replication and Elimination for
+              Reliability (IEEE Std 802.1CB-2017)", 2017,
+              <http://standards.ieee.org/about/get/>.
+
+   [IEEE8021Q]
+              IEEE 802.1, "Standard for Local and metropolitan area
+              networks--Bridges and Bridged Networks (IEEE Std 802.1Q-
+              2018)", 2018, <http://standards.ieee.org/about/get/>.
+
+   [IEEEP8021CBdb]
+              Mangin, C., "Extended Stream identification functions",
+              IEEE P802.1CBdb /D1.0 P802.1CBdb, September 2020,
+              <http://www.ieee802.org/1/files/private/db-drafts/
+              d1/802-1CBdb-d1-0.pdf>.
+
+   [RFC3985]  Bryant, S., Ed. and P. Pate, Ed., "Pseudo Wire Emulation
+              Edge-to-Edge (PWE3) Architecture", RFC 3985,
+              DOI 10.17487/RFC3985, March 2005,
+              <https://www.rfc-editor.org/info/rfc3985>.
+
+   [RFC4301]  Kent, S. and K. Seo, "Security Architecture for the
+              Internet Protocol", RFC 4301, DOI 10.17487/RFC4301,
+              December 2005, <https://www.rfc-editor.org/info/rfc4301>.
+
+   [RFC5921]  Bocci, M., Ed., Bryant, S., Ed., Frost, D., Ed., Levrau,
+              L., and L. Berger, "A Framework for MPLS in Transport
+              Networks", RFC 5921, DOI 10.17487/RFC5921, July 2010,
+              <https://www.rfc-editor.org/info/rfc5921>.
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 14]
+
+Internet-Draft            TSN over DetNet MPLS             November 2020
+
+
+   [RFC8655]  Finn, N., Thubert, P., Varga, B., and J. Farkas,
+              "Deterministic Networking Architecture", RFC 8655,
+              DOI 10.17487/RFC8655, October 2019,
+              <https://www.rfc-editor.org/info/rfc8655>.
+
+   [RFC8660]  Bashandy, A., Ed., Filsfils, C., Ed., Previdi, S.,
+              Decraene, B., Litkowski, S., and R. Shakir, "Segment
+              Routing with the MPLS Data Plane", RFC 8660,
+              DOI 10.17487/RFC8660, December 2019,
+              <https://www.rfc-editor.org/info/rfc8660>.
+
+Authors' Addresses
+
+   Balazs Varga (editor)
+   Ericsson
+   Magyar Tudosok krt. 11.
+   Budapest  1117
+   Hungary
+
+   Email: balazs.a.varga@ericsson.com
+
+
+   Janos Farkas
+   Ericsson
+   Magyar Tudosok krt. 11.
+   Budapest  1117
+   Hungary
+
+   Email: janos.farkas@ericsson.com
+
+
+   Andrew G. Malis
+   Malis Consulting
+
+   Email: agmalis@gmail.com
+
+
+   Stewart Bryant
+   Futurewei Technologies
+
+   Email: stewart.bryant@gmail.com
+
+
+   Don Fedyk
+   LabN Consulting, L.L.C.
+
+   Email: dfedyk@labn.net
+
+
+
+
+Varga, et al.              Expires May 7, 2021                 [Page 15]

--- a/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.txt
+++ b/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.txt
@@ -5,13 +5,13 @@
 DetNet                                                     B. Varga, Ed.
 Internet-Draft                                                 J. Farkas
 Intended status: Standards Track                                Ericsson
-Expires: May 7, 2021                                            A. Malis
+Expires: May 6, 2021                                            A. Malis
                                                         Malis Consulting
                                                                S. Bryant
                                                   Futurewei Technologies
                                                                 D. Fedyk
                                                  LabN Consulting, L.L.C.
-                                                        November 3, 2020
+                                                        November 2, 2020
 
 
    DetNet Data Plane: IEEE 802.1 Time Sensitive Networking over MPLS
@@ -37,7 +37,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 7, 2021.
+   This Internet-Draft will expire on May 6, 2021.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 1]
+Varga, et al.              Expires May 6, 2021                  [Page 1]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 2]
+Varga, et al.              Expires May 6, 2021                  [Page 2]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -165,7 +165,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 3]
+Varga, et al.              Expires May 6, 2021                  [Page 3]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -221,7 +221,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 4]
+Varga, et al.              Expires May 6, 2021                  [Page 4]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -277,7 +277,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 5]
+Varga, et al.              Expires May 6, 2021                  [Page 5]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -333,7 +333,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 6]
+Varga, et al.              Expires May 6, 2021                  [Page 6]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -389,7 +389,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 7]
+Varga, et al.              Expires May 6, 2021                  [Page 7]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -445,7 +445,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 8]
+Varga, et al.              Expires May 6, 2021                  [Page 8]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -501,7 +501,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                  [Page 9]
+Varga, et al.              Expires May 6, 2021                  [Page 9]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -557,7 +557,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 10]
+Varga, et al.              Expires May 6, 2021                 [Page 10]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -613,7 +613,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 11]
+Varga, et al.              Expires May 6, 2021                 [Page 11]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -669,7 +669,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 12]
+Varga, et al.              Expires May 6, 2021                 [Page 12]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -725,7 +725,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 13]
+Varga, et al.              Expires May 6, 2021                 [Page 13]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -781,7 +781,7 @@ Internet-Draft            TSN over DetNet MPLS             November 2020
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 14]
+Varga, et al.              Expires May 6, 2021                 [Page 14]
 
 Internet-Draft            TSN over DetNet MPLS             November 2020
 
@@ -837,4 +837,4 @@ Authors' Addresses
 
 
 
-Varga, et al.              Expires May 7, 2021                 [Page 15]
+Varga, et al.              Expires May 6, 2021                 [Page 15]

--- a/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.xml
+++ b/tsn-vpn-over-mpls/IDs/draft-ietf-detnet-tsn-vpn-over-mpls-04.xml
@@ -1,0 +1,737 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+<!ENTITY rfc2119 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
+<!ENTITY rfc3031 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3031.xml">
+<!ENTITY rfc3985 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3985.xml">
+<!ENTITY rfc5921 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5921.xml">
+<!ENTITY rfc8660 PUBLIC "" "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8660.xml">
+
+]>
+<?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
+<?rfc toc="yes"?>
+<?rfc symrefs="yes"?>
+<?rfc sortrefs="yes"?>
+<?rfc iprnotified="no"?>
+<?rfc strict="yes"?>
+<?rfc compact="yes"?>
+<?rfc subcompact="no"?>
+<rfc category="std"
+     docName="draft-ietf-detnet-tsn-vpn-over-mpls-04"
+         ipr="trust200902"
+         submissionType="IETF">
+  <front>
+    <title abbrev="TSN over DetNet MPLS">
+    DetNet Data Plane: IEEE 802.1 Time Sensitive Networking over MPLS</title>
+
+    <author role="editor" fullname="Bal&aacute;zs Varga" initials="B." surname="Varga">
+      <organization>Ericsson</organization>
+      <address>
+        <postal>
+          <street>Magyar Tudosok krt. 11.</street>
+          <city>Budapest</city>
+          <country>Hungary</country>
+          <code>1117</code>
+        </postal>
+        <email>balazs.a.varga@ericsson.com</email>
+      </address>
+    </author>
+
+    <author fullname="J&aacute;nos Farkas" initials="J." surname="Farkas">
+      <organization>Ericsson</organization>
+      <address>
+        <postal>
+          <street>Magyar Tudosok krt. 11.</street>
+          <city>Budapest</city>
+          <country>Hungary</country>
+          <code>1117</code>
+        </postal>
+        <email>janos.farkas@ericsson.com</email>
+      </address>
+    </author>
+
+    <author fullname="Andrew G. Malis" initials="A.G." surname="Malis">
+      <organization>Malis Consulting</organization>
+      <address>
+        <email>agmalis@gmail.com</email>
+      </address>
+    </author>
+
+    <author fullname="Stewart Bryant" initials="S." surname="Bryant">
+      <organization>Futurewei Technologies</organization>
+      <address>
+        <email>stewart.bryant@gmail.com</email>
+      </address>
+    </author>
+    <author fullname="Don Fedyk" initials="D." surname="Fedyk">
+      <organization>LabN Consulting, L.L.C.</organization>
+      <address>
+        <email>dfedyk@labn.net</email>
+      </address>
+    </author>
+
+  <date />
+  <workgroup>DetNet</workgroup>
+
+  <abstract>
+   <t>
+     This document specifies the Deterministic Networking data plane
+     when TSN networks are interconnected over a DetNet MPLS Network.
+   </t>
+  </abstract>
+  </front>
+
+ <middle>
+ <section title="Introduction" anchor="sec_intro">
+  <t>
+        The Time-Sensitive Networking Task Group (TSN TG) within IEEE 802.1 Working 
+        Group deals with deterministic services through IEEE 802 networks. 
+    Deterministic Networking (DetNet) defined by IETF is a service that can be 
+        offered by a L3 network to DetNet flows.  General background and concepts 
+        of DetNet can be found in <xref target="RFC8655"/>.
+  </t>
+  <t>
+        This document specifies the use of a DetNet MPLS network to interconnect TSN 
+        nodes/network segments. DetNet MPLS data plane is defined in 
+        <xref target="I-D.ietf-detnet-mpls"/>.
+        <vspace blankLines="100" />   </t>
+ </section>
+
+
+ <section title="Terminology">
+  <section title="Terms Used in This Document">
+  <t>
+        This document uses the terminology and concepts established in the DetNet 
+        architecture <xref target="RFC8655"/> and 
+        <xref target="I-D.ietf-detnet-data-plane-framework"/>, and 
+        <xref target="I-D.ietf-detnet-mpls"/>.  The reader is assumed 
+        to be familiar with these documents and their terminology.
+  </t>
+  </section>
+
+  <section title="Abbreviations">
+  <t>
+   The following abbreviations are used in this document:
+   <list style="hanging" hangIndent="14">
+    <t hangText="AC">Attachment Circuit.</t>
+    <t hangText="CE">Customer Edge equipment.</t>
+    <t hangText="CW">Control Word.</t>
+    <t hangText="DetNet">Deterministic Networking.</t>
+    <t hangText="DF">DetNet Flow.</t>
+    <t hangText="FRER">Frame Replication and Elimination for Redundancy 
+        (TSN function).</t>
+    <t hangText="L2">Layer 2.</t>
+    <t hangText="L2VPN">Layer 2 Virtual Private Network.</t>
+    <t hangText="L3">Layer 3.</t>
+    <t hangText="LSR">Label Switching Router.</t>
+    <t hangText="MPLS">Multiprotocol Label Switching.</t>
+    <t hangText="MPLS-TE">Multiprotocol Label Switching - Traffic Engineering.</t>
+    <t hangText="MPLS-TP">Multiprotocol Label Switching - Transport Profile.</t>
+    <t hangText="NSP">Native Service Processing.</t>
+    <t hangText="OAM">Operations, Administration, and Maintenance.</t>
+    <t hangText="PE">Provider Edge.</t>
+    <t hangText="PREOF">Packet Replication, Elimination and Ordering Functions.</t>
+    <t hangText="PW">PseudoWire.</t>
+    <t hangText="S-PE">Switching Provider Edge.</t>
+    <t hangText="T-PE">Terminating Provider Edge.</t>
+    <t hangText="TSN">Time-Sensitive Network.</t>
+   </list>
+  </t>
+  </section>
+
+  <section title="Requirements Language">
+  <t>
+    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+    "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+    "OPTIONAL" in this document are to be interpreted as described in
+    BCP 14 <xref target="RFC2119"/> <xref target="RFC8174"/> when, and
+    only when, they appear in all capitals, as shown here.
+   </t>
+   </section>
+ </section>  <!-- end of terminology -->
+
+<!-- =========================================== -->
+<!--            TSN over DetNet MPLS             -->
+<!-- =========================================== -->
+
+<section title="IEEE 802.1 TSN Over DetNet MPLS Data Plane Scenario"
+             anchor="sec_tsn_mpls_dt_dp_scen">
+
+  <t>
+   <xref target="fig_tsn_mpls_detnet"/> shows IEEE 802.1 TSN end
+   stations operating over a TSN aware DetNet service running over an MPLS
+   network.  DetNet Edge Nodes sit at the boundary of a DetNet domain. They are
+   responsible for mapping non-DetNet aware L2 traffic to DetNet services.
+   They also support the imposition and disposition of the required DetNet
+   encapsulation.  These are functionally similar to pseudowire (PW)
+   Terminating Provider Edge (T-PE) nodes which use MPLS-TE LSPs.  In this
+   example TSN Streams are simple applications over DetNet flows.  The specific
+   of this operation are discussed later in this document.
+  </t>
+
+<figure anchor="fig_tsn_mpls_detnet" align="center"
+title="A TSN over DetNet MPLS Enabled Network">
+<artwork align="center"><![CDATA[
+   TSN           Edge          Transit         Edge          TSN
+End System       Node           Node           Node       End System
+                (T-PE)         (LSR)          (T-PE)
+
++----------+                                             +----------+
+|   TSN    | <---------End to End TSN Service----------> |   TSN    |
+|  Applic. |                                             |  Applic. |
++----------+  +.........+                   +.........+  +----------+
+|          |  | \S-Proxy:                   :S-Proxy/ |  |          |
+|   TSN    |  |   +.+---+<-- DetNet flow -->+---+ |   |  |   TSN    |
+|          |  |TSN| |Svc|                   |Svc| |TSN|  |          |
++----------+  +---+ +---+    +----------+   +---+ +---+  +----------+
+|   L2     |  | L2| |Fwd|    |Forwarding|   |Fwd| |L2 |  |   L2     |
++------.---+  +-.-+ +-.-+    +---.----.-+   +--.+ +-.-+  +---.------+
+       :  Link  :     /  ,-----.  \   :  Link  :   /  ,-----. \
+       +........+     +-[  Sub  ]-+   +........+   +-[  TSN  ]-+
+                        [Network]                    [Network]
+                         `-----'                      `-----'
+
+                    |<------ DetNet MPLS ------>|
+        |<---------------------- TSN   --------------------->|
+
+]]></artwork>
+</figure>
+
+  <t>
+        In this example, edge nodes provide a service proxy function that 
+        "associates" the DetNet flows and native flows (i.e., TSN Streams) at
+        the edge of the DetNet domain.  TSN streams are treated as App-flows 
+		for DetNet. The whole DetNet domain behaves as a TSN relay node for 
+		the TSN streams. The service proxy behaves as a port of that TSN 
+		relay node. 
+  </t>
+
+  <t>
+   <xref target="fig_8021_detnet"/> illustrates how DetNet can provide services 
+   for IEEE 802.1 TSN end systems, CE1 and CE2, over a DetNet enabled MPLS 
+   network.  Edge nodes, E1 and E2, insert and remove required DetNet data
+   plane encapsulation.  The 'X' in the edge nodes and relay node, R1, 
+   represent a potential DetNet compound flow  packet replication and 
+   elimination point.  This conceptually parallels L2VPN services, and could
+   leverage existing related solutions as discussed below.
+  </t>
+
+  <figure align="center" anchor="fig_8021_detnet"
+  title="IEEE 802.1TSN Over DetNet">
+  <artwork><![CDATA[
+     TSN    |<------- End to End DetNet Service ------>|  TSN
+    Service |         Transit          Transit         | Service
+TSN  (AC)   |        |<-Tnl->|        |<-Tnl->|        |  (AC)  TSN
+End    |    V        V    1  V        V   2   V        V   |    End
+System |    +--------+       +--------+       +--------+   |  System
++---+  |    |   E1   |=======|   R1   |=======|   E2   |   |   +---+
+|   |--|----|._X_....|..DF1..|.._ _...|..DF3..|...._X_.|---|---|   |
+|CE1|  |    |    \   |       |   X    |       |   /    |   |   |CE2|
+|   |       |     \_.|..DF2..|._/ \_..|..DF4..|._/     |       |   |
++---+       |        |=======|        |=======|        |       +---+
+    ^       +--------+       +--------+       +--------+       ^
+    |        Edge Node       Relay Node        Edge Node       |
+    |          (T-PE)           (S-PE)          (T-PE)         |
+    |                                                          |
+    |<- TSN -> <------- TSN Over DetNet MPLS -------> <- TSN ->|
+    |                                                          |
+    |<-------- Time Sensitive Networking (TSN) Service ------->|
+
+    X   = Service protection
+    DFx = DetNet member flow x over a TE LSP
+]]>
+</artwork>
+</figure>
+
+  </section>
+
+<!-- ================================================= -->
+<!--            DetNet MPLS data plane OVERVIEW        -->
+<!-- ================================================= -->
+
+ <section title="DetNet MPLS Data Plane" anchor="sec_dt_dp">
+
+ <section title="Overview" anchor="sec_dt_dp_ov">
+ <t>
+        The basic approach defined in <xref target="I-D.ietf-detnet-mpls"/>
+        supports the DetNet service sub-layer based on existing pseudowire (PW) 
+        encapsulations and mechanisms, and supports the DetNet forwarding 
+        sub-layer based on existing MPLS Traffic Engineering encapsulations 
+        and mechanisms. 
+ </t>
+ <t>
+        A node operating on a DetNet flow in the Detnet service sub-layer, i.e. 
+        a node processing a DetNet packet which has the S-Label as top of stack 
+        uses the local context associated with that S-Label, for example a received 
+        F-Label, to determine what local DetNet operation(s) are applied to that 
+        packet. An S-Label may be unique when taken from the platform
+        label space <xref target="RFC3031"/>, which would enable correct DetNet flow
+        identification regardless of which input interface or LSP the packet arrives 
+        on. The service sub-layer functions (i.e., PREOF) use a DetNet control word 
+        (d-CW).
+ </t>
+ <t>
+    The DetNet MPLS data plane builds on MPLS Traffic Engineering
+    encapsulations and mechanisms to provide a forwarding sub-layer that
+    is responsible for providing resource allocation and explicit
+    routes.  The forwarding sub-layer is supported by one or more
+    forwarding labels (F-Labels).
+ </t>
+ <t>
+        DetNet edge/relay nodes are DetNet service sub-layer
+        aware, understand the particular needs of DetNet flows and
+        provide both DetNet service and forwarding sub-layer functions.
+        They add, remove and process d-CWs, S-Labels and F-labels as
+        needed.  MPLS DetNet nodes and transit nodes include
+        DetNet forwarding sub-layer functions, support for notably
+        explicit routes, and resources allocation to eliminate (or
+        reduce) congestion loss and jitter. Unlike other DetNet node types, 
+		transit nodes provide no service sub-layer processing.
+ </t>
+ </section>
+
+ <section anchor="tom-encap"
+               title="TSN over DetNet MPLS Encapsulation">
+ <t>
+        The basic encapsulation approach is to treat a TSN Stream as an App-flow 
+        from the DetNet MPLS perspective. The corresponding example shown in 
+        <xref target="fig_tsn_mpls_ex"/>.
+ </t>
+
+  <figure title="Example TSN over MPLS Encapsulation Formats"
+              anchor="fig_tsn_mpls_ex">
+        <artwork align="center"><![CDATA[
+
+           /->     +------+  +------+  +------+   TSN      ^ ^
+           |       |  X   |  |  X   |  |  X   |<- Appli    : :
+App-Flow <-+       +------+  +------+  +------+   cation   : :(1)
+ for MPLS  |       |TSN-L2|  |TSN-L2|  |TSN-L2|            : v
+           \-> +---+======+--+======+--+======+-----+      :
+                   | d-CW |  | d-CW |  | d-CW |            :
+DetNet-MPLS        +------+  +------+  +------+            :(2)
+                   |Labels|  |Labels|  |Labels|            v
+               +---+======+--+======+--+======+-----+
+Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
+                   +------+  +------+  +------+
+                                       |  IP  |
+                                       +------+
+                                       |  L2  |
+                                       +------+
+    (1) TSN Stream 
+    (2) DetNet MPLS Flow
+    ]]>
+        </artwork>
+  </figure>
+
+ <t>
+        In the figure, "Application" indicates the application payload carried by 
+        the TSN network. "MPLS App-Flow" indicates that the TSN Stream is the 
+        payload from the perspective of the DetNet MPLS data plane defined in 
+        <xref target="I-D.ietf-detnet-mpls"/>. A single DetNet MPLS flow 
+        can aggregate multiple TSN Streams.
+ </t>
+ </section>
+
+ </section>  <!-- end of DetNet MPLS data plane overview -->
+
+<!-- ================================================= -->
+<!--            TSN over DetNet MPLS procedures        -->
+<!-- ================================================= -->
+
+ <section title="TSN over MPLS Data Plane Procedures" anchor="tom_proc">
+
+  <t>
+        Description of Edge Nodes procedures and functions for TSN over DetNet MPLS
+        scenario follows the concept of <xref target="RFC3985"/> and covers the 
+        Edge Nodes components shown on <xref target="fig_tsn_mpls_detnet"/>. In 
+        this section the following procedures of DetNet Edge Nodes are described:
+        <list style="symbols">
+                <t>
+                        TSN related (<xref target="tom_tsn_proc"/>)
+                </t><t>
+                        DetNet Service Proxy (<xref target="tom_svc_prx_proc"/>)
+                </t><t>
+                        DetNet service and forwarding sub-layer (<xref target="tom_dn_sub_proc"/>)
+                </t>
+        </list>
+  </t>
+  <t>  
+		The sub-sections describe procedures for forwarding packets by DetNet 
+		Edge nodes, where such packets are received from either directly 
+		connected CEs (TSN nodes) or some other DetNet Edge nodes.
+  </t>
+  
+
+  <section title="Edge Node TSN Procedures" anchor="tom_tsn_proc">
+    <t>
+        The Time-Sensitive Networking (TSN) Task Group of the IEEE 802.1 
+                Working Group have defined (and are defining) a number of amendments 
+                to <xref target="IEEE8021Q">IEEE 802.1Q</xref> that provide zero 
+                congestion loss and bounded latency in bridged networks.
+        <xref target="IEEE8021CB">IEEE 802.1CB</xref> defines packet 
+                replication and elimination functions for a TSN network.
+          </t>
+          <t>
+		  	  The implementation of TSN entity (i.e., TSN packet processing 
+			  functions) must be compliant with the relevant IEEE 802.1 
+			  standards.
+          </t>
+          <t>
+                TSN specific functions are executed on the data received by 
+                the DetNet Edge Node from the connected CE before forwarded to 
+				connected CE(s) or presentation to the DetNet Service Proxy function for 
+                transmission across the DetNet domain, or on the data received from 
+                a DetNet PW by a PE before it is output on the Attachment Circuit(s) (AC). 
+          </t>
+          <t>
+                TSN packet processing function(s) of Edge Nodes (T-PE) are belonging to the 
+                native service processing (NSP) <xref target="RFC3985"/> 
+                block. This is similar to other functionalities being defined by standard 
+                bodies other than the IETF (for example in case of Ethernet: stripping, 
+                overwriting or adding VLAN tags, etc.). Depending on the TSN role of 
+                the Edge Node in the end-to-end TSN service selected TSN functions 
+                are supported. 
+    </t>
+    <t>		
+			When a PE receives a packet from a CE, on a given AC with DetNet service,
+			it first checks via Stream Identification 
+			(see Clause 6. of <xref target="IEEE8021CB">IEEE 802.1CB</xref> and
+            <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref>) 
+			whether the packet belongs 
+			to a configured TSN Stream (i.e., App-flow from DetNet perspective). 
+			If no Stream ID is matched and no other (VPN) service is configured 
+			for the AC then packet MUST be dropped. If there is a matching TSN 
+			Stream then the Stream-ID specific TSN functions are executed 
+			(e.g., ingress policing, header field manipulation in case 
+			of active Stream Identification, FRER, etc.). Source MAC lookup 
+			may also be used for local MAC address learning.
+    </t>
+    <t>		
+			If the PE decides to forward the packet, the packet MUST be forwarded 
+			according to the TSN Stream specific configuration to connected CE(s) 
+			(in case of local bridging) and/or to the DetNet Service Proxy 
+			(in case of forwarding to remote CE(s) required). If there are no 
+			TSN Stream specific forwarding configurations the PE MUST flood 
+			the packet to other locally attached CE(s) and to the DetNet Service 
+			Proxy. If the administrative policy on the PE does not allow 
+			flooding the PE MUST drop the packet.
+    </t>
+    <t>		
+			When a TSN entity of the PE receives a packet from the DetNet 
+			Service Proxy, it first checks via Stream Identification 
+			(see Clause 6. of <xref target="IEEE8021CB">IEEE 802.1CB</xref> and
+            <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref>) whether 
+			the packet belongs to a configured TSN Stream. If no Stream ID is 
+			matched then packet is dropped. If there is a matching TSN 
+			Stream then the Stream ID specific TSN functions are executed 
+			(e.g., header field manipulation in case of active Stream 
+			Identification, FRER, etc.). Source MAC lookup may also be used for 
+			local MAC address learning.
+    </t>
+    <t>		
+			If the PE decides to forward the packet, the packet is forwarded 
+			according to the TSN Stream specific configuration to connected CE(s).
+			If there are no TSN Stream specific forwarding configurations the 
+			PE floods the packet to locally attached CE(s). If the 
+			administrative policy on the PE does not allow flooding the PE  
+			drops the packet.
+    </t>
+    <t>
+            Implementations of this document SHALL use management and
+            control information to ensure TSN specific functions of the Edge Node
+            according to the expectations of the connected TSN network. 
+    </t>
+  </section>
+
+  <section title="Edge Node DetNet Service Proxy Procedures" anchor="tom_svc_prx_proc">
+          <t>
+                The Service Proxy
+                function maps between App-flows and DetNet flows.
+				The DetNet Edge Node TSN entity MUST support the TSN Stream
+                identification functions and the related managed objects as
+                defined in Clause 6. and Clause 9. of 
+				<xref target="IEEE8021CB">IEEE 802.1CB</xref> and
+                <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref> to
+                recognize the App-flow related packets.  The Service Proxy
+                presents TSN Streams as an App-flow to a DetNet Flow.
+		  </t>
+		<t>		
+			When a DetNet Service Proxy receives a packet from the TSN Entity
+			it MUST check whether such an App-flow is present in its mapping table.
+			If present it associates the internal DetNet flow-ID to the packet and 
+			MUST forward it to the DetNet Service and Forwarding sub-layers. If 
+			no matching statement is present it MUST drop the packet.
+		</t>
+		<t>		
+			When a DetNet Service Proxy receives a packet from the DetNet Service 
+			and Forwarding sub-layers it MUST be forwarded to the Edge Node 
+			TSN Entity. 
+		</t>
+		  <t>
+                Implementations of this document SHALL use management and
+                control information to map a TSN Stream to a DetNet flow. 
+                N:1 mapping (aggregating multiple TSN Streams in a single
+                DetNet flow) SHALL be supported. The management or control
+                function that provisions flow mapping SHALL ensure that
+                adequate resources are allocated and configured to provide
+                proper service requirements of the mapped flows.
+        </t>
+        <t>
+                Due to the (intentional) similarities of the DetNet PREOF and
+                TSN FRER functions service protection function interworking is
+                possible between the TSN and the DetNet domains. Such service
+                protection interworking scenarios MAY require to copy sequence
+                number fields from TSN (L2) to PW (MPLS) encapsulation.
+                However, such interworking is out-of-scope in this document and
+                left for further study.
+        </t>
+        <t>
+                A MPLS DetNet flow is configured to carry any number of
+                TSN flows. The DetNet flow specific bandwidth profile SHOULD 
+				match the required bandwidth of the App-flow aggregate.  
+        </t>
+  </section>
+
+  <section title="Edge Node DetNet Service and Forwarding Sub-Layer Procedures" anchor="tom_dn_sub_proc">
+          <t>
+                In the design of <xref target="I-D.ietf-detnet-mpls"/> an MPLS service 
+                label (the S-Label), similar to a pseudowire (PW) label 
+                <xref target="RFC3985"/>, is used to identify both the DetNet flow 
+                identity and the payload MPLS payload type.  The DetNet sequence 
+                number is carried in the DetNet Control word (d-CW) which carries the 
+                Data/OAM discriminator as well. In 
+                <xref target="I-D.ietf-detnet-mpls"/> two sequence number sizes 
+                are supported: a 16 bit sequence number and a 28 bit sequence number.
+    </t>
+    <t>
+                PREOF functions and the provided service recovery is available
+                only within the DetNet domain as the DetNet flow-ID and the DetNet
+                sequence number are not valid outside the DetNet network.  MPLS
+                (DetNet) Edge node terminates all related information elements 
+                encoded in the MPLS labels.
+        </t>
+        <t>
+                The LSP used to forward the DetNet packet may be of any type (MPLS-LDP, 
+                MPLS-TE, MPLS-TP <xref target="RFC5921"/>, or MPLS-SR 
+                <xref target="RFC8660"/>).  The LSP 
+                (F-Label) label and/or the S-Label may be used to indicate the queue 
+                processing as well as the forwarding parameters.
+        </t>
+    <t>		
+			When a PE receives a packet from the Service Proxy function it MUST
+			add to the packet the DetNet flow-ID specific S-label and create a 
+			d-CW. The PE MUST forward the packet according to the configured 
+			DetNet Service and Forwarding sub-layer rules to other PE nodes. 
+    </t>
+    <t>		
+			When a PE receives an MPLS packet from a remote PE, then, after 
+			processing the MPLS label stack, if the top MPLS label ends up being 
+			a DetNet S-label that was advertised by this node, then the PE 
+			MUST forward the packet according to the configured DetNet Service and 
+			Forwarding sub-layer rules to other PE nodes or via the Detnet Service 
+			Proxy function towards locally connected CE(s). 
+    </t>
+    <t>
+                For further details on DetNet Service and Forwarding sub-layers 
+				see <xref target="I-D.ietf-detnet-mpls"/>.
+        </t>
+  </section>
+
+ </section>  <!-- End of Procedures Section -->
+
+
+<!-- ========================================================== -->
+<!--          Management and Control Plane Considerations       -->
+<!-- ========================================================== -->
+
+ <section title="Controller Plane (Management and Control) Considerations" anchor="cp_considerations">
+
+   <t>
+        TSN Stream(s) to DetNet flow mapping related information are
+        required only for the service proxy function of MPLS (DetNet) Edge nodes. 
+        From the Data Plane perspective there is no practical difference
+		based on the origin of flow mapping related information	(management 
+		plane or control plane).
+   </t>
+        <t>
+            The following summarizes the set of information that is needed to
+            configure TSN over DetNet MPLS:
+            <list style="symbols">
+			  <t>TSN related configuration information according to the 
+			     TSN role of the DetNet MPLS node, as per 
+				 <xref target="IEEE8021Q"/>, <xref target="IEEE8021CB"/> and
+			     <xref target="IEEEP8021CBdb"/>. </t>
+			  <t>DetNet MPLS related configuration information according to the 
+			     DetNet role of the DetNet MPLS node, as per 
+			     <xref target="I-D.ietf-detnet-mpls"/>. </t>
+              <t>App-Flow identification information to map received TSN 
+			  Stream(s) to the DetNet flow. Parameters of TSN stream 
+			  identification are defined in <xref target="IEEE8021CB"/> and 
+			  <xref target="IEEEP8021CBdb"/>. </t>
+            </list>
+            This information MUST be provisioned per DetNet flow.
+        </t>
+        <t>
+			Mappings between DetNet and TSN management and control planes are 
+			out of scope of the document. Some of the challanges are 
+			highligthed below.
+        </t>
+   <t>
+        MPLS DetNet Edge nodes are member of both the DetNet domain and the
+        connected TSN network. From the TSN network perspective the MPLS
+        (DetNet) Edge node has a "TSN relay node" role, so TSN specific
+        management and control plane functionalities must be implemented.
+        There are many similarities in the management plane techniques used in
+        DetNet and TSN, but that is not the case for the control plane
+        protocols. For example, RSVP-TE and MSRP behaves differently.  
+		Therefore management and control plane design is an important aspect 
+		of scenarios, where	mapping between DetNet and TSN is required.
+   </t>
+   <t>
+        Note that, as the DetNet network is just a portion of the end to end TSN
+        path (i.e., single hop from Ethernet perspective), some parameters
+        (e.g., delay) may differ significantly.  Since there is no interworking
+        function the bandwidth of DetNet network is assumed to be set large enough to
+        handle all TSN Flows it will support.  At the egress of the Detnet Domain the MPLS
+        headers are stripped and the TSN flow continues on as a normal TSN
+        flow. 
+	</t>
+	<t>
+        In order to use a DetNet network to interconnect TSN segments,
+        TSN specific information must be converted to DetNet domain
+        specific ones. TSN Stream ID(s) and stream(s) related
+        parameters/requirements must be converted to a DetNet flow-ID and 
+        flow related parameters/requirements.
+   </t>
+   <t>
+        In some case it may be challenging to determine some egress node
+        related information. For example, it may be not trivial to
+        locate the egress point/interface of a TSN Streams with a 
+        multicast destination MAC address. Such scenarios may
+        require interaction between control and management plane
+        functions and between DetNet and TSN domains.
+   </t>
+   <t>
+        Mapping between DetNet flow identifiers and TSN Stream
+        identifiers, if not provided explicitly, can be done by the service
+        proxy function of an MPLS (DetNet) Edge node locally based on information
+        provided for configuration of the TSN Stream identification functions 
+        (e.g., Mask-and-Match Stream identification).
+   </t>
+   <t>
+        Triggering the setup/modification of a DetNet flow in the
+        DetNet network is an example where management and/or
+        control plane interactions are required between the DetNet
+        and the TSN network. 
+   </t>
+   <t>
+        Configuration of TSN specific functions (e.g., FRER)
+        inside the TSN network is a TSN domain specific decision 
+        and may not be visible in the DetNet domain. Service protection
+        interworking scenarios are left for further study.
+   </t>
+</section> <!-- End of Management and Control Plane COnsiderations -->
+
+<section title="Security Considerations">
+  <t>
+     Security considerations for DetNet are described in detail in <xref
+             target="I-D.ietf-detnet-security"/>. General security
+     considerations are described in <xref
+             target="RFC8655"/>.  
+  </t>
+  <t>     
+     DetNet MPLS data plane specific considerations are summarized and 
+	 described in <xref target="I-D.ietf-detnet-mpls"/> including any 
+	 application flow types. This document focuses on the scenario where TSN 
+	 Streams are the application flows for DetNet and it is already covered 
+	 by those DetNet MPLS data plane security considerations. 
+    </t>
+</section>
+
+<section anchor="iana" title="IANA Considerations">
+  <t>
+   This document makes no IANA requests.
+  </t>
+</section>
+
+<section anchor="acks" title="Acknowledgements">
+   <t>
+    The authors wish to thank Norman Finn, Lou Berger, Craig Gunther,
+	Christophe Mangin and Jouni Korhonen for their various contributions
+	to this work.
+   </t>
+</section>
+</middle>
+
+<back>
+  <references title="Normative References">
+   &rfc2119;
+   <?rfc include="reference.RFC.3031"?>
+   <?rfc include="reference.RFC.8174"?>
+   <?rfc include="reference.I-D.ietf-detnet-mpls"?>
+  </references>
+  <references title="Informative References">
+   &rfc3985;
+   &rfc5921;
+   &rfc8660;
+      <?rfc include="reference.RFC.8655"?>
+      <?rfc include="reference.I-D.ietf-detnet-data-plane-framework"?>
+      <?rfc include="reference.I-D.ietf-detnet-security"?>
+      <?rfc include="reference.RFC.4301"?>
+
+
+    <reference anchor="IEEE802.1AE-2018"
+      target="https://ieeexplore.ieee.org/document/8585421">
+      <front>
+        <title>IEEE Std 802.1AE-2018 MAC Security (MACsec)</title>
+        <author>
+          <organization>IEEE Standards Association</organization>
+        </author>
+        <date year="2018" />
+      </front>
+    </reference>
+
+      <reference anchor="IEEE8021Q"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks--Bridges
+          and Bridged Networks (IEEE Std 802.1Q-2018)</title>
+          <author>
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date year="2018"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
+
+      <reference anchor="IEEE8021CB"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks - 
+		  Frame Replication and Elimination for Reliability 
+		  (IEEE Std 802.1CB-2017)</title>
+          <author>
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date year="2017"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
+
+      <reference anchor="IEEEP8021CBdb"
+                 target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf">
+        <front>
+          <title>Extended Stream identification functions</title>
+          <author initials="C. M." surname="Mangin" fullname="Christophe Mangin">
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date month="September" year="2020"/>
+        </front>
+        <seriesInfo name="IEEE P802.1CBdb /D1.0" value="P802.1CBdb"/>
+        <format type="PDF" target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf"/>
+      </reference>
+
+
+  </references>
+
+ </back>
+</rfc>

--- a/tsn-vpn-over-mpls/draft-ietf-detnet-tsn-vpn-over-mpls.xml
+++ b/tsn-vpn-over-mpls/draft-ietf-detnet-tsn-vpn-over-mpls.xml
@@ -281,22 +281,11 @@ System |    +--------+       +--------+       +--------+   |  System
         aware, understand the particular needs of DetNet flows and
         provide both DetNet service and forwarding sub-layer functions.
         They add, remove and process d-CWs, S-Labels and F-labels as
-        needed.  MPLS enabled DetNet nodes can enhance the
-        reliability of delivery by enabling the replication of packets
-        where multiple copies, possibly over multiple paths, are
-        forwarded through the DetNet domain.  They can also eliminate
-        surplus previously replicated copies of DetNet packets.
-        MPLS (DetNet) nodes also include
+        needed.  MPLS DetNet nodes and transit nodes include
         DetNet forwarding sub-layer functions, support for notably
         explicit routes, and resources allocation to eliminate (or
-        reduce) congestion loss and jitter.
- </t>
- <t>
-        DetNet transit nodes reside wholly within a DetNet domain, and
-        also provide DetNet forwarding sub-layer functions in accordance
-        with the performance required by a DetNet flow carried over an
-        LSP. Unlike other DetNet node types, transit nodes provide no
-        service sub-layer processing.
+        reduce) congestion loss and jitter. Unlike other DetNet node types, 
+		transit nodes provide no service sub-layer processing.
  </t>
  </section>
 
@@ -383,7 +372,7 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
           </t>
           <t>
 		  	  The implementation of TSN entity (i.e., TSN packet processing 
-			  functions) MUST be compliant with the relevant IEEE 802.1 
+			  functions) must be compliant with the relevant IEEE 802.1 
 			  standards.
           </t>
           <t>
@@ -404,17 +393,17 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
     </t>
     <t>		
 			When a PE receives a packet from a CE, on a given AC with DetNet service,
-			it MUST first check via Stream Identification 
+			it first checks via Stream Identification 
 			(see Clause 6. of <xref target="IEEE8021CB">IEEE 802.1CB</xref> and
             <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref>) 
 			whether the packet belongs 
 			to a configured TSN Stream (i.e., App-flow from DetNet perspective). 
 			If no Stream ID is matched and no other (VPN) service is configured 
 			for the AC then packet MUST be dropped. If there is a matching TSN 
-			Stream then the Stream-ID specific TSN functions MUST be executed 
+			Stream then the Stream-ID specific TSN functions are executed 
 			(e.g., ingress policing, header field manipulation in case 
 			of active Stream Identification, FRER, etc.). Source MAC lookup 
-			MAY also be used for local MAC address learning.
+			may also be used for local MAC address learning.
     </t>
     <t>		
 			If the PE decides to forward the packet, the packet MUST be forwarded 
@@ -428,28 +417,28 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
     </t>
     <t>		
 			When a TSN entity of the PE receives a packet from the DetNet 
-			Service Proxy, it MUST first check via Stream Identification 
+			Service Proxy, it first checks via Stream Identification 
 			(see Clause 6. of <xref target="IEEE8021CB">IEEE 802.1CB</xref> and
             <xref target="IEEEP8021CBdb">IEEE P802.1CBdb</xref>) whether 
 			the packet belongs to a configured TSN Stream. If no Stream ID is 
-			matched then packet MUST be dropped. If there is a matching TSN 
-			Stream then the Stream ID specific TSN functions MUST be executed 
+			matched then packet is dropped. If there is a matching TSN 
+			Stream then the Stream ID specific TSN functions are executed 
 			(e.g., header field manipulation in case of active Stream 
-			Identification, FRER, etc.). Source MAC lookup MAY also be used for 
+			Identification, FRER, etc.). Source MAC lookup may also be used for 
 			local MAC address learning.
     </t>
     <t>		
-			If the PE decides to forward the packet, the packet MUST be forwarded 
+			If the PE decides to forward the packet, the packet is forwarded 
 			according to the TSN Stream specific configuration to connected CE(s).
 			If there are no TSN Stream specific forwarding configurations the 
-			PE MUST flood the packet to locally attached CE(s). If the 
-			administrative policy on the PE does not allow flooding the PE MUST 
-			drop the packet.
+			PE floods the packet to locally attached CE(s). If the 
+			administrative policy on the PE does not allow flooding the PE  
+			drops the packet.
     </t>
     <t>
-                Implementations of this document SHALL use management and
-                control information to ensure TSN specific functions of the Edge Node
-                according to the expectations of the connected TSN network. 
+            Implementations of this document SHALL use management and
+            control information to ensure TSN specific functions of the Edge Node
+            according to the expectations of the connected TSN network. 
     </t>
   </section>
 
@@ -575,11 +564,16 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
 			     DetNet role of the DetNet MPLS node, as per 
 			     <xref target="I-D.ietf-detnet-mpls"/>. </t>
               <t>App-Flow identification information to map received TSN 
-			  Stream(s) to the DetNet flow. Parameters fo TSN stream 
+			  Stream(s) to the DetNet flow. Parameters of TSN stream 
 			  identification are defined in <xref target="IEEE8021CB"/> and 
 			  <xref target="IEEEP8021CBdb"/>. </t>
             </list>
             This information MUST be provisioned per DetNet flow.
+        </t>
+        <t>
+			Mappings between DetNet and TSN management and control planes are 
+			out of scope of the document. Some of the challanges are 
+			highligthed below.
         </t>
    <t>
         MPLS DetNet Edge nodes are member of both the DetNet domain and the
@@ -696,42 +690,44 @@ Link/Sub-Network   |  L2  |  | TSN  |  | UDP  |
       </front>
     </reference>
 
-   <reference anchor="IEEE8021Q"
-     target="http://standards.ieee.org/about/get/">
-    <front>
-     <title>Standard for Local and metropolitan area networks--Bridges and Bridged Networks (IEEE Std 802.1Q-2014)</title>
-     <author>
-      <organization>IEEE 802.1</organization>
-     </author>
-     <date year="2014"/>
-    </front>
-    <format type="PDF" target="http://standards.ieee.org/about/get/"/>
-   </reference>
-
-   <reference anchor="IEEE8021CB"
-    target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf">
-    <front>
-        <title>Draft Standard for Local and metropolitan area networks - Seamless Redundancy</title>
-        <author initials="N. F." surname="Finn" fullname="Norman Finn">
+      <reference anchor="IEEE8021Q"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks--Bridges
+          and Bridged Networks (IEEE Std 802.1Q-2018)</title>
+          <author>
             <organization>IEEE 802.1</organization>
-        </author>
-        <date month="December" year="2015"/>
-    </front>
-    <seriesInfo name="IEEE P802.1CB /D2.1" value="P802.1CB"/>
-    <format type="PDF" target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf"/>
-   </reference>
+          </author>
+          <date year="2018"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
+
+      <reference anchor="IEEE8021CB"
+                 target="http://standards.ieee.org/about/get/">
+        <front>
+          <title>Standard for Local and metropolitan area networks - 
+		  Frame Replication and Elimination for Reliability 
+		  (IEEE Std 802.1CB-2017)</title>
+          <author>
+            <organization>IEEE 802.1</organization>
+          </author>
+          <date year="2017"/>
+        </front>
+        <format type="PDF" target="http://standards.ieee.org/about/get/"/>
+      </reference>
 
       <reference anchor="IEEEP8021CBdb"
-                 target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf">
+                 target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf">
         <front>
           <title>Extended Stream identification functions</title>
           <author initials="C. M." surname="Mangin" fullname="Christophe Mangin">
             <organization>IEEE 802.1</organization>
           </author>
-          <date month="August" year="2019"/>
+          <date month="September" year="2020"/>
         </front>
-        <seriesInfo name="IEEE P802.1CBdb /D0.2" value="P802.1CBdb"/>
-        <format type="PDF" target="http://www.ieee802.org/1/files/private/cb-drafts/d2/802-1CB-d2-1.pdf"/>
+        <seriesInfo name="IEEE P802.1CBdb /D1.0" value="P802.1CBdb"/>
+        <format type="PDF" target="http://www.ieee802.org/1/files/private/db-drafts/d1/802-1CBdb-d1-0.pdf"/>
       </reference>
 
 

--- a/tsn-vpn-over-mpls/draft-ietf-detnet-tsn-vpn-over-mpls.xml
+++ b/tsn-vpn-over-mpls/draft-ietf-detnet-tsn-vpn-over-mpls.xml
@@ -16,7 +16,7 @@
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
 <rfc category="std"
-     docName="draft-ietf-detnet-tsn-vpn-over-mpls-04"
+     docName="draft-ietf-detnet-tsn-vpn-over-mpls-05"
          ipr="trust200902"
          submissionType="IETF">
   <front>


### PR DESCRIPTION
TSN related documents are updated as follows:
draft-ietf-detnet-ip-over-tsn AND draft-ietf-detnet-mpls-over-tsn
- type changed to informational
- overview shortened
- changing TSN related conformance language to informative text
- stating that mappings between DetNet and TSN management and control planes are out of scope of the document
- updating references

draft-ietf-detnet-tsn-vpn-over-mpls
- overview shortened
- fixing 5.1 and 5.2 (changing TSN related conformance language to informative text)
- stating that mappings between DetNet and TSN management and control planes are out of scope of the document
- updating references
